### PR TITLE
WIP: Refactor Installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 sudo: false
 
 php:
-  - '5.4'
   - '5.5'
   - '5.6'
   - '7.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 sudo: false
 
 php:
-  - '5.3'
   - '5.4'
   - '5.5'
   - '5.6'
@@ -17,5 +16,4 @@ before_script:
   - mysql -e 'create database symphony_test;'
 
 script:
-  - symphony/conductor requirements
   - symphony/conductor install test/travis_ci_config.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,27 @@ php:
   - '5.4'
   - '5.5'
   - '5.6'
+  - '7.0'
+  - 'hhvm'
+
+matrix:
+  allow_failures:
+  - php: hhvm
 
 services:
   - mysql
 
 install:
-  - composer install -o
+  - composer install -o --no-interaction
 
 before_script:
   - mysql -e 'create database symphony_test;'
 
 script:
-  - symphony/conductor install test/travis_ci_config.php
+  - symphony/conductor install test/travis_ci_config.php --override --no-interaction -vvv
+  - ./vendor/bin/phpcs --colors --extensions=php symphony/ install/
+
+
+cache:
+  directories:
+    - $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: php
+sudo: false
+
+php:
+  - '5.3'
+  - '5.4'
+  - '5.5'
+  - '5.6'
+
+services:
+  - mysql
+
+install:
+  - composer install -o
+
+before_script:
+  - mysql -e 'create database symphony_test;'
+
+script:
+  - symphony/conductor requirements
+  - symphony/conductor install test/travis_ci_config.php

--- a/README.markdown
+++ b/README.markdown
@@ -37,7 +37,7 @@ Useful places:
 
 ## Server requirements
 
-- PHP 5.6 or above
+- PHP 5.5.9 or above
 - PHP’s LibXML module, with the XSLT extension enabled (`--with-xsl`)
 - PHP’s built in `json` functions, which are enabled by default in PHP 5.2 and above; if they are missing, ensure PHP wasn’t compiled with `--disable-json`
 - [Composer](https://getcomposer.org/)

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
     "ext-libxml": "*",
     "ext-pdo_mysql": "*",
     "ext-xsl": "*",
-    "monolog/monolog": "1.*"
+    "monolog/monolog": "1.*",
+    "symfony/console": "^3.1"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "2.*",
-    "symfony/console": "^3.1"
   },
   "minimum-stability": "stable",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "wiki": "https://github.com/symphonycms/symphony-2/wiki"
   },
   "require": {
-    "php": ">=5.5",
+    "php": ">=5.5.9",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-libxml": "*",
@@ -26,7 +26,7 @@
     "symfony/console": "^3.1"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": "2.*"
+    "squizlabs/php_codesniffer": "^2.6"
   },
   "minimum-stability": "stable",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "symfony/console": "^3.1"
   },
   "require-dev": {
-    "squizlabs/php_codesniffer": "2.*",
+    "squizlabs/php_codesniffer": "2.*"
   },
   "minimum-stability": "stable",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,39 +1,44 @@
 {
-    "name": "symphonycms/symphony-2",
-    "version": "3.0.0-alpha.1",
-    "description": "Symphony is a PHP & MySQL based CMS that utilises XML and XSLT as its core technologies.",
-    "homepage": "http://www.getsymphony.com",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Symphony Team",
-            "email": "team@getsymphony.com"
-        }
-    ],
-    "support": {
-      "forum": "http://www.getsymphony.com/discuss/",
-      "issues": "https://github.com/symphonycms/symphony-2/issues",
-      "wiki": "https://github.com/symphonycms/symphony-2/wiki"
-    },
-    "require": {
-      "php": ">=5.5",
-      "ext-curl": "*",
-      "ext-json": "*",
-      "ext-libxml": "*",
-      "ext-pdo_mysql": "*",
-      "ext-xsl": "*",
-      "monolog/monolog": "1.*"
-    },
-    "require-dev": {
-      "squizlabs/php_codesniffer": "2.*"
-    },
-    "minimum-stability": "stable",
-    "autoload": {
-      "classmap": ["symphony/content", "symphony/lib", "symphony/template", "install"],
-      "files": [
-        "symphony/lib/boot/func.utilities.php",
-        "symphony/lib/boot/defines.php",
-        "symphony/lib/toolkit/util.validators.php"
-      ]
+  "name": "symphonycms/symphony-2",
+  "version": "3.0.0-alpha.1",
+  "description": "Symphony is a PHP & MySQL based CMS that utilises XML and XSLT as its core technologies.",
+  "homepage": "http://www.getsymphony.com",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Symphony Team",
+      "email": "team@getsymphony.com"
     }
+  ],
+  "support": {
+    "forum": "http://www.getsymphony.com/discuss/",
+    "issues": "https://github.com/symphonycms/symphony-2/issues",
+    "wiki": "https://github.com/symphonycms/symphony-2/wiki"
+  },
+  "require": {
+    "php": ">=5.5",
+    "ext-curl": "*",
+    "ext-json": "*",
+    "ext-libxml": "*",
+    "ext-pdo_mysql": "*",
+    "ext-xsl": "*",
+    "monolog/monolog": "1.*"
+  },
+  "require-dev": {
+    "squizlabs/php_codesniffer": "2.*",
+    "symfony/console": "^3.1"
+  },
+  "minimum-stability": "stable",
+  "autoload": {
+    "classmap": ["symphony/content", "symphony/lib", "symphony/template", "install"],
+    "files": [
+      "symphony/lib/boot/func.utilities.php",
+      "symphony/lib/boot/defines.php",
+      "symphony/lib/toolkit/util.validators.php"
+    ],
+    "psr-4": {
+      "SymphonyCms\\": "symphony/",
+      "SymphonyCms\\Installer\\": "install/"
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   },
   "minimum-stability": "stable",
   "autoload": {
-    "classmap": ["symphony/content", "symphony/lib", "symphony/template", "install"],
+    "classmap": ["symphony/content", "symphony/lib", "symphony/template"],
     "files": [
       "symphony/lib/boot/func.utilities.php",
       "symphony/lib/boot/defines.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "eb79955f3ad63bb54fad04fd27dfa23e",
-    "content-hash": "daf25b31527313020017ffee6cc85da7",
+    "hash": "ab74089fcf043b42a0f1c1e80143f4d2",
+    "content-hash": "7bd3dfbfef642dde423bdfa48041dc07",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -202,6 +202,125 @@
                 "standards"
             ],
             "time": "2016-05-30 22:24:32"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "64a4d43b045f07055bb197650159769604cb2a92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/64a4d43b045f07055bb197650159769604cb2a92",
+                "reference": "64a4d43b045f07055bb197650159769604cb2a92",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/process": "~2.8|~3.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-14 11:18:07"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-05-18 14:26:46"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ab74089fcf043b42a0f1c1e80143f4d2",
-    "content-hash": "7bd3dfbfef642dde423bdfa48041dc07",
+    "hash": "944000adef0684afcd1105a3aa3d2595",
+    "content-hash": "6d3072cdec622644cc0317dfd1a1b0a6",
     "packages": [
         {
             "name": "monolog/monolog",
@@ -122,86 +122,6 @@
                 "psr-3"
             ],
             "time": "2012-12-21 11:40:51"
-        }
-    ],
-    "packages-dev": [
-        {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
-                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
-                "shasum": ""
-            },
-            "require": {
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
-                }
-            ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
-            "keywords": [
-                "phpcs",
-                "standards"
-            ],
-            "time": "2016-05-30 22:24:32"
         },
         {
             "name": "symfony/console",
@@ -321,6 +241,86 @@
                 "shim"
             ],
             "time": "2016-05-18 14:26:46"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
+                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2016-05-30 22:24:32"
         }
     ],
     "aliases": [],

--- a/install/Steps/CreateDatabase.php
+++ b/install/Steps/CreateDatabase.php
@@ -1,88 +1,88 @@
 <?php
-    namespace SymphonyCms\Installer\Steps;
+namespace SymphonyCms\Installer\Steps;
 
-    use Author;
-    use Configuration;
-    use Cryptography;
-    use DatabaseException;
-    use Exception;
-    use Symphony;
+use Author;
+use Configuration;
+use Cryptography;
+use DatabaseException;
+use Exception;
+use Symphony;
 
-    class CreateDatabase extends DefaultStep
+class CreateDatabase extends DefaultStep
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Configuration $config, array $data)
     {
-        /**
-         * {@inheritdoc}
-         */
-        public function handle(Configuration $config, array $data)
-        {
-            // MySQL: Establishing connection
-            $this->logger->info('MYSQL: Establishing Connection');
+        // MySQL: Establishing connection
+        $this->logger->info('MYSQL: Establishing Connection');
+
+        try {
+            Symphony::Database()->connect(
+                $config->get('host', 'database'),
+                $config->get('user', 'database'),
+                $config->get('password', 'database'),
+                $config->get('port', 'database'),
+                $config->get('db', 'database')
+            );
+        } catch (DatabaseException $e) {
+            throw new Exception(
+                'There was a problem while trying to establish a connection to the MySQL server. Please check your settings.'
+            );
+        }
+
+        if (Symphony::Database()->tableExists($config->get('tbl_prefix', 'database') . '%') && !$this->override) {
+            $this->logger->error('MYSQL: Database table prefix is already in use. Change prefix or run installation with the `--override` flag.', [
+                'prefix' => $config->get('tbl_prefix', 'database'),
+                'db' => $config->get('db', 'database')
+            ]);
+
+            return false;
+        }
+
+        // MySQL: Setting prefix & importing schema
+        Symphony::Database()->setPrefix($config->get('tbl_prefix', 'database'));
+        $this->logger->info('MYSQL: Importing Table Schema');
+
+        try {
+            Symphony::Database()->import(file_get_contents(INSTALL . '/includes/install.sql'));
+        } catch (DatabaseException $e) {
+            throw new Exception(sprintf(
+                'There was an error while trying to import data to the database. MySQL returned: %s:%s',
+                $e->getDatabaseErrorCode(),
+                $e->getDatabaseErrorMessage()
+            ));
+        }
+
+        // MySQL: Creating default author
+        if (isset($data['user'])) {
+            $this->logger->info('MYSQL: Creating Default Author');
 
             try {
-                Symphony::Database()->connect(
-                    $config->get('host', 'database'),
-                    $config->get('user', 'database'),
-                    $config->get('password', 'database'),
-                    $config->get('port', 'database'),
-                    $config->get('db', 'database')
-                );
-            } catch (DatabaseException $e) {
-                throw new Exception(
-                    'There was a problem while trying to establish a connection to the MySQL server. Please check your settings.'
-                );
-            }
+                // Clean all the user data.
+                $userData = array_map([Symphony::Database(), 'cleanValue'], $data['user']);
 
-            if (Symphony::Database()->tableExists($config->get('tbl_prefix', 'database') . '%') && !$this->override) {
-                $this->logger->error('MYSQL: Database table prefix is already in use. Change prefix or run installation with the `--override` flag.', [
-                    'prefix' => $config->get('tbl_prefix', 'database'),
-                    'db' => $config->get('db', 'database')
-                ]);
-
-                return false;
-            }
-
-            // MySQL: Setting prefix & importing schema
-            Symphony::Database()->setPrefix($config->get('tbl_prefix', 'database'));
-            $this->logger->info('MYSQL: Importing Table Schema');
-
-            try {
-                Symphony::Database()->import(file_get_contents(INSTALL . '/includes/install.sql'));
+                $author = new Author;
+                $author->set('user_type', 'developer');
+                $author->set('primary', 'yes');
+                $author->set('username', $userData['username']);
+                $author->set('password', Cryptography::hash($userData['password']));
+                $author->set('first_name', $userData['firstname']);
+                $author->set('last_name', $userData['lastname']);
+                $author->set('email', $userData['email']);
+                $author->commit();
             } catch (DatabaseException $e) {
                 throw new Exception(sprintf(
-                    'There was an error while trying to import data to the database. MySQL returned: %s:%s',
+                    'There was an error while trying create the default author. MySQL returned: %s:%s',
                     $e->getDatabaseErrorCode(),
                     $e->getDatabaseErrorMessage()
                 ));
             }
-
-            // MySQL: Creating default author
-            if (isset($data['user'])) {
-                $this->logger->info('MYSQL: Creating Default Author');
-
-                try {
-                    // Clean all the user data.
-                    $userData = array_map([Symphony::Database(), 'cleanValue'], $data['user']);
-
-                    $author = new Author;
-                    $author->set('user_type', 'developer');
-                    $author->set('primary', 'yes');
-                    $author->set('username', $userData['username']);
-                    $author->set('password', Cryptography::hash($userData['password']));
-                    $author->set('first_name', $userData['firstname']);
-                    $author->set('last_name', $userData['lastname']);
-                    $author->set('email', $userData['email']);
-                    $author->commit();
-                } catch (DatabaseException $e) {
-                    throw new Exception(sprintf(
-                        'There was an error while trying create the default author. MySQL returned: %s:%s',
-                        $e->getDatabaseErrorCode(),
-                        $e->getDatabaseErrorMessage()
-                    ));
-                }
-            } else {
-                $this->logger->info('MYSQL: Skipping Default Author creation');
-            }
-
-            return true;
+        } else {
+            $this->logger->info('MYSQL: Skipping Default Author creation');
         }
+
+        return true;
     }
+}

--- a/install/Steps/CreateDatabase.php
+++ b/install/Steps/CreateDatabase.php
@@ -1,13 +1,13 @@
 <?php
     namespace SymphonyCms\Installer\Steps;
 
-    use \Psr\Log\LoggerInterface;
-    use Configuration;
-    use DatabaseException;
-    use Symphony;
     use Author;
+    use Configuration;
     use Cryptography;
+    use DatabaseException;
     use Exception;
+    use Psr\Log\LoggerInterface;
+    use Symphony;
 
     class CreateDatabase implements Step
     {

--- a/install/Steps/CreateDatabase.php
+++ b/install/Steps/CreateDatabase.php
@@ -1,0 +1,87 @@
+<?php
+
+    use \Psr\Log\LoggerInterface;
+
+    class CreateDatabase implements Step
+    {
+        /**
+         * @var LoggerInterface
+         */
+        protected $logger;
+
+        /**
+         * CreateManifest constructor.
+         *
+         * @param LoggerInterface $logger
+         */
+        public function __construct(LoggerInterface $logger)
+        {
+            $this->logger = $logger;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function handle(Configuration $config)
+        {
+            // MySQL: Establishing connection
+            $this->logger->info('MYSQL: Establishing Connection');
+
+            try {
+                Symphony::Database()->connect(
+                    $config->get('host', 'database'),
+                    $config->get('user', 'database'),
+                    $config->get('password', 'database'),
+                    $config->get('port', 'database'),
+                    $config->get('db', 'database')
+                );
+            } catch (DatabaseException $e) {
+                throw new Exception(
+                    'There was a problem while trying to establish a connection to the MySQL server. Please check your settings.'
+                );
+            }
+
+            // MySQL: Setting prefix & character encoding
+            Symphony::Database()->setPrefix($config->get('tbl_prefix', 'database'));
+
+            // MySQL: Importing schema
+            $this->logger->info('MYSQL: Importing Table Schema');
+
+            try {
+                Symphony::Database()->import(file_get_contents(INSTALL . '/includes/install.sql'));
+            } catch (DatabaseException $e) {
+                throw new Exception(sprintf(
+                    'There was an error while trying to import data to the database. MySQL returned: %s:%s',
+                    $e->getDatabaseErrorCode(),
+                    $e->getDatabaseErrorMessage()
+                ));
+            }
+
+            // MySQL: Creating default author
+            $this->logger->info('MYSQL: Creating Default Author');
+
+            try {
+                Symphony::Database()->insert(array(
+                    'id' => 1,
+                    'username' => Symphony::Database()->cleanValue($_POST['fields']['user']['username']),
+                    'password' => Cryptography::hash(Symphony::Database()->cleanValue($_POST['fields']['user']['password'])),
+                    'first_name' => Symphony::Database()->cleanValue($_POST['fields']['user']['firstname']),
+                    'last_name' => Symphony::Database()->cleanValue($_POST['fields']['user']['lastname']),
+                    'email' => Symphony::Database()->cleanValue($_POST['fields']['user']['email']),
+                    'last_seen' => null,
+                    'user_type' => 'developer',
+                    'primary' => 'yes',
+                    'default_area' => null,
+                    'auth_token_active' => 'no'
+                ), 'tbl_authors');
+            } catch (DatabaseException $e) {
+                throw new Exception(sprintf(
+                    'There was an error while trying create the default author. MySQL returned: %s:%s',
+                    $e->getDatabaseErrorCode(),
+                    $e->getDatabaseErrorMessage()
+                ));
+            }
+
+            return true;
+        }
+    }

--- a/install/Steps/CreateHtaccess.php
+++ b/install/Steps/CreateHtaccess.php
@@ -1,10 +1,10 @@
 <?php
     namespace SymphonyCms\Installer\Steps;
 
-    use \Psr\Log\LoggerInterface;
     use Configuration;
-    use General;
     use Exception;
+    use General;
+    use Psr\Log\LoggerInterface;
 
     class CreateHtaccess implements Step
     {

--- a/install/Steps/CreateHtaccess.php
+++ b/install/Steps/CreateHtaccess.php
@@ -4,40 +4,37 @@
     use Configuration;
     use Exception;
     use General;
-    use Psr\Log\LoggerInterface;
 
-    class CreateHtaccess implements Step
+    class CreateHtaccess extends DefaultStep
     {
-        /**
-         * @var LoggerInterface
-         */
-        protected $logger;
-
-        /**
-         * CreateManifest constructor.
-         *
-         * @param LoggerInterface $logger
-         */
-        public function __construct(LoggerInterface $logger)
-        {
-            $this->logger = $logger;
-        }
-
         /**
          * {@inheritdoc}
          */
         public function handle(Configuration $config, array $data)
         {
             // Writing htaccess file
-            $this->logger->info('CONFIGURING: Frontend');
+            $this->logger->info('CONFIGURING: Apache Rewrite Rules');
 
-            $rewrite_base = ltrim(preg_replace('/\/install$/i', null, dirname($_SERVER['PHP_SELF'])), '/');
+            if (APP_MODE === 'console') {
+                $rewrite_base = basename(DOCROOT);
+            } else {
+                $rewrite_base = ltrim(preg_replace('/\/install$/i', null, dirname($_SERVER['PHP_SELF'])), '/');
+            }
+
             $htaccess = str_replace(
                 '<!-- REWRITE_BASE -->', $rewrite_base,
                 file_get_contents(INSTALL . '/includes/htaccess.txt')
             );
 
-            if (!General::writeFile(DOCROOT . "/.htaccess", $htaccess, $config->get('write_mode', 'file'), 'a')) {
+            // If the step can override, replace the entire .htaccess file.
+            if (file_exists(DOCROOT . "/.htaccess") && $this->override) {
+                $this->logger->info('CONFIGURING: Replacing existing .htaccess file');
+                $file_mode = 'w';
+            } else {
+                $file_mode = 'a';
+            }
+
+            if (!General::writeFile(DOCROOT . "/.htaccess", $htaccess, $config->get('write_mode', 'file'), $file_mode)) {
                 throw new Exception('Could not write ‘.htaccess’ file. Check permission on ' . DOCROOT);
             }
 

--- a/install/Steps/CreateHtaccess.php
+++ b/install/Steps/CreateHtaccess.php
@@ -1,44 +1,44 @@
 <?php
-    namespace SymphonyCms\Installer\Steps;
+namespace SymphonyCms\Installer\Steps;
 
-    use Configuration;
-    use Exception;
-    use General;
+use Configuration;
+use Exception;
+use General;
 
-    class CreateHtaccess extends DefaultStep
+class CreateHtaccess extends DefaultStep
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Configuration $config, array $data)
     {
-        /**
-         * {@inheritdoc}
-         */
-        public function handle(Configuration $config, array $data)
-        {
-            // Writing htaccess file
-            $this->logger->info('CONFIGURING: Apache Rewrite Rules');
+        // Writing htaccess file
+        $this->logger->info('CONFIGURING: Apache Rewrite Rules');
 
-            if (APP_MODE === 'console') {
-                $rewrite_base = basename(DOCROOT);
-            } else {
-                $rewrite_base = ltrim(preg_replace('/\/install$/i', null, dirname($_SERVER['PHP_SELF'])), '/');
-            }
-
-            $htaccess = str_replace(
-                '<!-- REWRITE_BASE -->', $rewrite_base,
-                file_get_contents(INSTALL . '/includes/htaccess.txt')
-            );
-
-            // If the step can override, replace the entire .htaccess file.
-            if (file_exists(DOCROOT . "/.htaccess") && $this->override) {
-                $this->logger->info('CONFIGURING: Replacing existing .htaccess file');
-                $file_mode = 'w';
-            } else {
-                $file_mode = 'a';
-            }
-
-            if (!General::writeFile(DOCROOT . "/.htaccess", $htaccess, $config->get('write_mode', 'file'), $file_mode)) {
-                throw new Exception('Could not write ‘.htaccess’ file. Check permission on ' . DOCROOT);
-            }
-
-            return true;
+        if (APP_MODE === 'console') {
+            $rewrite_base = basename(DOCROOT);
+        } else {
+            $rewrite_base = ltrim(preg_replace('/\/install$/i', null, dirname($_SERVER['PHP_SELF'])), '/');
         }
 
+        $htaccess = str_replace(
+            '<!-- REWRITE_BASE -->',
+            $rewrite_base,
+            file_get_contents(INSTALL . '/includes/htaccess.txt')
+        );
+
+        // If the step can override, replace the entire .htaccess file.
+        if (file_exists(DOCROOT . "/.htaccess") && $this->override) {
+            $this->logger->info('CONFIGURING: Replacing existing .htaccess file');
+            $file_mode = 'w';
+        } else {
+            $file_mode = 'a';
+        }
+
+        if (!General::writeFile(DOCROOT . "/.htaccess", $htaccess, $config->get('write_mode', 'file'), $file_mode)) {
+            throw new Exception('Could not write ‘.htaccess’ file. Check permission on ' . DOCROOT);
+        }
+
+        return true;
     }
+}

--- a/install/Steps/CreateHtaccess.php
+++ b/install/Steps/CreateHtaccess.php
@@ -1,0 +1,43 @@
+<?php
+
+    use \Psr\Log\LoggerInterface;
+
+    class CreateHtaccess implements Step
+    {
+        /**
+         * @var LoggerInterface
+         */
+        protected $logger;
+
+        /**
+         * CreateManifest constructor.
+         *
+         * @param LoggerInterface $logger
+         */
+        public function __construct(LoggerInterface $logger)
+        {
+            $this->logger = $logger;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function handle(Configuration $config)
+        {
+            // Writing htaccess file
+            $this->logger->info('CONFIGURING: Frontend');
+
+            $rewrite_base = ltrim(preg_replace('/\/install$/i', null, dirname($_SERVER['PHP_SELF'])), '/');
+            $htaccess = str_replace(
+                '<!-- REWRITE_BASE -->', $rewrite_base,
+                file_get_contents(INSTALL . '/includes/htaccess.txt')
+            );
+
+            if (!General::writeFile(DOCROOT . "/.htaccess", $htaccess, $config->get('write_mode', 'directory'), 'a')) {
+                throw new Exception('Could not write ‘.htaccess’ file. Check permission on ' . DOCROOT);
+            }
+
+            return true;
+        }
+
+    }

--- a/install/Steps/CreateHtaccess.php
+++ b/install/Steps/CreateHtaccess.php
@@ -1,6 +1,10 @@
 <?php
+    namespace SymphonyCms\Installer\Steps;
 
     use \Psr\Log\LoggerInterface;
+    use Configuration;
+    use General;
+    use Exception;
 
     class CreateHtaccess implements Step
     {
@@ -22,7 +26,7 @@
         /**
          * {@inheritdoc}
          */
-        public function handle(Configuration $config)
+        public function handle(Configuration $config, array $data)
         {
             // Writing htaccess file
             $this->logger->info('CONFIGURING: Frontend');
@@ -33,7 +37,7 @@
                 file_get_contents(INSTALL . '/includes/htaccess.txt')
             );
 
-            if (!General::writeFile(DOCROOT . "/.htaccess", $htaccess, $config->get('write_mode', 'directory'), 'a')) {
+            if (!General::writeFile(DOCROOT . "/.htaccess", $htaccess, $config->get('write_mode', 'file'), 'a')) {
                 throw new Exception('Could not write ‘.htaccess’ file. Check permission on ' . DOCROOT);
             }
 

--- a/install/Steps/CreateManifest.php
+++ b/install/Steps/CreateManifest.php
@@ -1,0 +1,58 @@
+<?php
+
+    use \Psr\Log\LoggerInterface;
+
+    class CreateManifest implements Step
+    {
+        /**
+         * @var LoggerInterface
+         */
+        protected $logger;
+
+        /**
+         * CreateManifest constructor.
+         *
+         * @param LoggerInterface $logger
+         */
+        public function __construct(LoggerInterface $logger)
+        {
+            $this->logger = $logger;
+        }
+
+        /**
+         * Return the directories that should be created.
+         *
+         * @return array
+         */
+        public function getManifestDirectories()
+        {
+            return [
+                'manifest' => MANIFEST,
+                'logs'     => MANIFEST . '/logs',
+                'cache'    => MANIFEST . '/cache',
+                'tmp'      => MANIFEST . '/tmp'
+            ];
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function handle(Configuration $config)
+        {
+            foreach ($this->getManifestDirectories() as $name => $dir) {
+                $this->logger->info(sprintf(
+                    'WRITING: Creating ‘%s‘ folder',
+                    $name
+                ));
+
+                if (!General::realiseDirectory($dir, $config->get('write_mode', 'directory'))) {
+                    throw new Exception(sprintf(
+                        'Could not create ‘%s’ directory. Check permission on the root folder.',
+                        $name
+                    ));
+                }
+            }
+
+            return true;
+        }
+    }

--- a/install/Steps/CreateManifest.php
+++ b/install/Steps/CreateManifest.php
@@ -4,25 +4,9 @@
     use Configuration;
     use Exception;
     use General;
-    use Psr\Log\LoggerInterface;
 
-    class CreateManifest implements Step
+    class CreateManifest extends DefaultStep
     {
-        /**
-         * @var LoggerInterface
-         */
-        protected $logger;
-
-        /**
-         * CreateManifest constructor.
-         *
-         * @param LoggerInterface $logger
-         */
-        public function __construct(LoggerInterface $logger)
-        {
-            $this->logger = $logger;
-        }
-
         /**
          * Return the directories that should be created.
          *
@@ -44,6 +28,24 @@
         public function handle(Configuration $config, array $data)
         {
             foreach ($this->getManifestDirectories() as $name => $dir) {
+                if (is_dir($dir)) {
+                    if ($this->override) {
+                        $this->logger->info(sprintf(
+                            'REMOVING: Deleting ‘%s‘ folder',
+                            $name
+                        ));
+
+                        General::deleteDirectory($dir);
+                    } else {
+                        $this->logger->info(sprintf(
+                            'SKIPPING: `%s` folder exists',
+                            $name
+                        ));
+
+                        continue;
+                    }
+                }
+
                 $this->logger->info(sprintf(
                     'WRITING: Creating ‘%s‘ folder',
                     $name

--- a/install/Steps/CreateManifest.php
+++ b/install/Steps/CreateManifest.php
@@ -1,6 +1,10 @@
 <?php
+    namespace SymphonyCms\Installer\Steps;
 
     use \Psr\Log\LoggerInterface;
+    use Configuration;
+    use General;
+    use Exception;
 
     class CreateManifest implements Step
     {
@@ -37,7 +41,7 @@
         /**
          * {@inheritdoc}
          */
-        public function handle(Configuration $config)
+        public function handle(Configuration $config, array $data)
         {
             foreach ($this->getManifestDirectories() as $name => $dir) {
                 $this->logger->info(sprintf(

--- a/install/Steps/CreateManifest.php
+++ b/install/Steps/CreateManifest.php
@@ -1,64 +1,64 @@
 <?php
-    namespace SymphonyCms\Installer\Steps;
+namespace SymphonyCms\Installer\Steps;
 
-    use Configuration;
-    use Exception;
-    use General;
+use Configuration;
+use Exception;
+use General;
 
-    class CreateManifest extends DefaultStep
+class CreateManifest extends DefaultStep
+{
+    /**
+     * Return the directories that should be created.
+     *
+     * @return array
+     */
+    public function getManifestDirectories()
     {
-        /**
-         * Return the directories that should be created.
-         *
-         * @return array
-         */
-        public function getManifestDirectories()
-        {
-            return [
-                'manifest' => MANIFEST,
-                'logs'     => MANIFEST . '/logs',
-                'cache'    => MANIFEST . '/cache',
-                'tmp'      => MANIFEST . '/tmp'
-            ];
-        }
+        return [
+            'manifest' => MANIFEST,
+            'logs'     => MANIFEST . '/logs',
+            'cache'    => MANIFEST . '/cache',
+            'tmp'      => MANIFEST . '/tmp'
+        ];
+    }
 
-        /**
-         * {@inheritdoc}
-         */
-        public function handle(Configuration $config, array $data)
-        {
-            foreach ($this->getManifestDirectories() as $name => $dir) {
-                if (is_dir($dir)) {
-                    if ($this->override) {
-                        $this->logger->info(sprintf(
-                            'REMOVING: Deleting ‘%s‘ folder',
-                            $name
-                        ));
-
-                        General::deleteDirectory($dir);
-                    } else {
-                        $this->logger->info(sprintf(
-                            'SKIPPING: `%s` folder exists',
-                            $name
-                        ));
-
-                        continue;
-                    }
-                }
-
-                $this->logger->info(sprintf(
-                    'WRITING: Creating ‘%s‘ folder',
-                    $name
-                ));
-
-                if (!General::realiseDirectory($dir, $config->get('write_mode', 'directory'))) {
-                    throw new Exception(sprintf(
-                        'Could not create ‘%s’ directory. Check permission on the root folder.',
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Configuration $config, array $data)
+    {
+        foreach ($this->getManifestDirectories() as $name => $dir) {
+            if (is_dir($dir)) {
+                if ($this->override) {
+                    $this->logger->info(sprintf(
+                        'REMOVING: Deleting ‘%s‘ folder',
                         $name
                     ));
+
+                    General::deleteDirectory($dir);
+                } else {
+                    $this->logger->info(sprintf(
+                        'SKIPPING: `%s` folder exists',
+                        $name
+                    ));
+
+                    continue;
                 }
             }
 
-            return true;
+            $this->logger->info(sprintf(
+                'WRITING: Creating ‘%s‘ folder',
+                $name
+            ));
+
+            if (!General::realiseDirectory($dir, $config->get('write_mode', 'directory'))) {
+                throw new Exception(sprintf(
+                    'Could not create ‘%s’ directory. Check permission on the root folder.',
+                    $name
+                ));
+            }
         }
+
+        return true;
     }
+}

--- a/install/Steps/CreateManifest.php
+++ b/install/Steps/CreateManifest.php
@@ -1,10 +1,10 @@
 <?php
     namespace SymphonyCms\Installer\Steps;
 
-    use \Psr\Log\LoggerInterface;
     use Configuration;
-    use General;
     use Exception;
+    use General;
+    use Psr\Log\LoggerInterface;
 
     class CreateManifest implements Step
     {

--- a/install/Steps/CreateWorkspace.php
+++ b/install/Steps/CreateWorkspace.php
@@ -1,6 +1,10 @@
 <?php
+    namespace SymphonyCms\Installer\Steps;
 
     use \Psr\Log\LoggerInterface;
+    use Configuration;
+    use General;
+    use Exception;
 
     class CreateWorkspace implements Step
     {
@@ -38,7 +42,7 @@
         /**
          * {@inheritdoc}
          */
-        public function handle(Configuration $config)
+        public function handle(Configuration $config, array $data)
         {
             foreach ($this->getWorkspaceDirectories() as $name => $dir) {
                 $this->logger->info(sprintf(

--- a/install/Steps/CreateWorkspace.php
+++ b/install/Steps/CreateWorkspace.php
@@ -4,25 +4,9 @@
     use Configuration;
     use Exception;
     use General;
-    use Psr\Log\LoggerInterface;
 
-    class CreateWorkspace implements Step
+    class CreateWorkspace extends DefaultStep
     {
-        /**
-         * @var LoggerInterface
-         */
-        protected $logger;
-
-        /**
-         * CreateManifest constructor.
-         *
-         * @param LoggerInterface $logger
-         */
-        public function __construct(LoggerInterface $logger)
-        {
-            $this->logger = $logger;
-        }
-
         /**
          * Return the directories that should be created.
          *

--- a/install/Steps/CreateWorkspace.php
+++ b/install/Steps/CreateWorkspace.php
@@ -1,10 +1,10 @@
 <?php
     namespace SymphonyCms\Installer\Steps;
 
-    use \Psr\Log\LoggerInterface;
     use Configuration;
-    use General;
     use Exception;
+    use General;
+    use Psr\Log\LoggerInterface;
 
     class CreateWorkspace implements Step
     {

--- a/install/Steps/CreateWorkspace.php
+++ b/install/Steps/CreateWorkspace.php
@@ -1,0 +1,59 @@
+<?php
+
+    use \Psr\Log\LoggerInterface;
+
+    class CreateWorkspace implements Step
+    {
+        /**
+         * @var LoggerInterface
+         */
+        protected $logger;
+
+        /**
+         * CreateManifest constructor.
+         *
+         * @param LoggerInterface $logger
+         */
+        public function __construct(LoggerInterface $logger)
+        {
+            $this->logger = $logger;
+        }
+
+        /**
+         * Return the directories that should be created.
+         *
+         * @return array
+         */
+        public function getWorkspaceDirectories()
+        {
+            return [
+                'workspace'     => WORKSPACE,
+                'data-sources'  => DATASOURCES,
+                'events'        => EVENTS,
+                'pages'         => PAGES,
+                'utilities'     => UTILITIES
+            ];
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function handle(Configuration $config)
+        {
+            foreach ($this->getWorkspaceDirectories() as $name => $dir) {
+                $this->logger->info(sprintf(
+                    'WRITING: Creating ‘%s‘ folder',
+                    $name
+                ));
+
+                if (!General::realiseDirectory($dir, $config->get('write_mode', 'directory'))) {
+                    throw new Exception(sprintf(
+                        'Could not create ‘%s’ directory. Check permission on the root folder.',
+                        $name
+                    ));
+                }
+            }
+
+            return true;
+        }
+    }

--- a/install/Steps/CreateWorkspace.php
+++ b/install/Steps/CreateWorkspace.php
@@ -1,47 +1,47 @@
 <?php
-    namespace SymphonyCms\Installer\Steps;
+namespace SymphonyCms\Installer\Steps;
 
-    use Configuration;
-    use Exception;
-    use General;
+use Configuration;
+use Exception;
+use General;
 
-    class CreateWorkspace extends DefaultStep
+class CreateWorkspace extends DefaultStep
+{
+    /**
+     * Return the directories that should be created.
+     *
+     * @return array
+     */
+    public function getWorkspaceDirectories()
     {
-        /**
-         * Return the directories that should be created.
-         *
-         * @return array
-         */
-        public function getWorkspaceDirectories()
-        {
-            return [
-                'workspace'     => WORKSPACE,
-                'data-sources'  => DATASOURCES,
-                'events'        => EVENTS,
-                'pages'         => PAGES,
-                'utilities'     => UTILITIES
-            ];
-        }
+        return [
+            'workspace'     => WORKSPACE,
+            'data-sources'  => DATASOURCES,
+            'events'        => EVENTS,
+            'pages'         => PAGES,
+            'utilities'     => UTILITIES
+        ];
+    }
 
-        /**
-         * {@inheritdoc}
-         */
-        public function handle(Configuration $config, array $data)
-        {
-            foreach ($this->getWorkspaceDirectories() as $name => $dir) {
-                $this->logger->info(sprintf(
-                    'WRITING: Creating ‘%s‘ folder',
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Configuration $config, array $data)
+    {
+        foreach ($this->getWorkspaceDirectories() as $name => $dir) {
+            $this->logger->info(sprintf(
+                'WRITING: Creating ‘%s‘ folder',
+                $name
+            ));
+
+            if (!General::realiseDirectory($dir, $config->get('write_mode', 'directory'))) {
+                throw new Exception(sprintf(
+                    'Could not create ‘%s’ directory. Check permission on the root folder.',
                     $name
                 ));
-
-                if (!General::realiseDirectory($dir, $config->get('write_mode', 'directory'))) {
-                    throw new Exception(sprintf(
-                        'Could not create ‘%s’ directory. Check permission on the root folder.',
-                        $name
-                    ));
-                }
             }
-
-            return true;
         }
+
+        return true;
     }
+}

--- a/install/Steps/DefaultStep.php
+++ b/install/Steps/DefaultStep.php
@@ -1,0 +1,36 @@
+<?php
+
+    namespace SymphonyCms\Installer\Steps;
+
+    use Psr\Log\LoggerInterface;
+
+    abstract class DefaultStep implements Step
+    {
+        /**
+         * @var LoggerInterface
+         */
+        protected $logger;
+
+        /**
+         * @var boolean
+         */
+        protected $override = false;
+
+        /**
+         * CreateManifest constructor.
+         *
+         * @param LoggerInterface $logger
+         */
+        public function __construct(LoggerInterface $logger)
+        {
+            $this->logger = $logger;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function setOverride($override = false)
+        {
+            $this->override = $override;
+        }
+    }

--- a/install/Steps/DefaultStep.php
+++ b/install/Steps/DefaultStep.php
@@ -1,36 +1,35 @@
 <?php
+namespace SymphonyCms\Installer\Steps;
 
-    namespace SymphonyCms\Installer\Steps;
+use Psr\Log\LoggerInterface;
 
-    use Psr\Log\LoggerInterface;
+abstract class DefaultStep implements Step
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
 
-    abstract class DefaultStep implements Step
+    /**
+     * @var boolean
+     */
+    protected $override = false;
+
+    /**
+     * CreateManifest constructor.
+     *
+     * @param LoggerInterface $logger
+     */
+    public function __construct(LoggerInterface $logger)
     {
-        /**
-         * @var LoggerInterface
-         */
-        protected $logger;
-
-        /**
-         * @var boolean
-         */
-        protected $override = false;
-
-        /**
-         * CreateManifest constructor.
-         *
-         * @param LoggerInterface $logger
-         */
-        public function __construct(LoggerInterface $logger)
-        {
-            $this->logger = $logger;
-        }
-
-        /**
-         * {@inheritdoc}
-         */
-        public function setOverride($override = false)
-        {
-            $this->override = $override;
-        }
+        $this->logger = $logger;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOverride($override = false)
+    {
+        $this->override = $override;
+    }
+}

--- a/install/Steps/EnableExtensions.php
+++ b/install/Steps/EnableExtensions.php
@@ -1,52 +1,52 @@
 <?php
-    namespace SymphonyCms\Installer\Steps;
+namespace SymphonyCms\Installer\Steps;
 
-    use Configuration;
-    use DirectoryIterator;
-    use Exception;
-    use ExtensionManager;
-    use General;
+use Configuration;
+use DirectoryIterator;
+use Exception;
+use ExtensionManager;
+use General;
 
-    class EnableExtensions extends DefaultStep
+class EnableExtensions extends DefaultStep
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Configuration $config, array $data)
     {
-        /**
-         * {@inheritdoc}
-         */
-        public function handle(Configuration $config, array $data)
-        {
-            // Write extensions folder
-            if (!is_dir(EXTENSIONS)) {
-                // Create extensions folder
-                $this->logger->info('WRITING: Creating ‘extensions’ folder (/extensions)');
-                if (!General::realiseDirectory(EXTENSIONS, $config->get('write_mode', 'directory'))) {
-                    throw new Exception('Could not create ‘extension’ directory. Check permission on the root folder.');
-                }
-
-                return true;
-            }
-
-            // Install existing extensions
-            $this->logger->info('CONFIGURING: Installing existing extensions');
-            foreach (new DirectoryIterator(EXTENSIONS) as $e) {
-                if ($e->isDot() || $e->isFile() || !is_file($e->getRealPath() . '/extension.driver.php')) {
-                    continue;
-                }
-
-                $handle = $e->getBasename();
-                try {
-                    $this->logger->debug('Enabling the extension ‘' . $handle . '’.');
-                    if (!ExtensionManager::enable($handle)) {
-                        $this->logger->warning('Could not enable the extension ‘' . $handle . '’.');
-                    }
-                } catch (Exception $ex) {
-                    $this->logger->warning(sprintf(
-                        'Could not enable the extension ‘%s’. %s',
-                        $handle,
-                        $ex->getMessage()
-                    ));
-                }
+        // Write extensions folder
+        if (!is_dir(EXTENSIONS)) {
+            // Create extensions folder
+            $this->logger->info('WRITING: Creating ‘extensions’ folder (/extensions)');
+            if (!General::realiseDirectory(EXTENSIONS, $config->get('write_mode', 'directory'))) {
+                throw new Exception('Could not create ‘extension’ directory. Check permission on the root folder.');
             }
 
             return true;
         }
+
+        // Install existing extensions
+        $this->logger->info('CONFIGURING: Installing existing extensions');
+        foreach (new DirectoryIterator(EXTENSIONS) as $e) {
+            if ($e->isDot() || $e->isFile() || !is_file($e->getRealPath() . '/extension.driver.php')) {
+                continue;
+            }
+
+            $handle = $e->getBasename();
+            try {
+                $this->logger->debug('Enabling the extension ‘' . $handle . '’.');
+                if (!ExtensionManager::enable($handle)) {
+                    $this->logger->warning('Could not enable the extension ‘' . $handle . '’.');
+                }
+            } catch (Exception $ex) {
+                $this->logger->warning(sprintf(
+                    'Could not enable the extension ‘%s’. %s',
+                    $handle,
+                    $ex->getMessage()
+                ));
+            }
+        }
+
+        return true;
     }
+}

--- a/install/Steps/EnableExtensions.php
+++ b/install/Steps/EnableExtensions.php
@@ -6,25 +6,9 @@
     use Exception;
     use ExtensionManager;
     use General;
-    use Psr\Log\LoggerInterface;
 
-    class EnableExtensions implements Step
+    class EnableExtensions extends DefaultStep
     {
-        /**
-         * @var LoggerInterface
-         */
-        protected $logger;
-
-        /**
-         * CreateManifest constructor.
-         *
-         * @param LoggerInterface $logger
-         */
-        public function __construct(LoggerInterface $logger)
-        {
-            $this->logger = $logger;
-        }
-
         /**
          * {@inheritdoc}
          */
@@ -50,6 +34,7 @@
 
                 $handle = $e->getBasename();
                 try {
+                    $this->logger->debug('Enabling the extension ‘' . $handle . '’.');
                     if (!ExtensionManager::enable($handle)) {
                         $this->logger->warning('Could not enable the extension ‘' . $handle . '’.');
                     }

--- a/install/Steps/EnableExtensions.php
+++ b/install/Steps/EnableExtensions.php
@@ -1,6 +1,12 @@
 <?php
+    namespace SymphonyCms\Installer\Steps;
 
     use \Psr\Log\LoggerInterface;
+    use Configuration;
+    use General;
+    use Exception;
+    use DirectoryIterator;
+    use ExtensionManager;
 
     class EnableExtensions implements Step
     {
@@ -22,7 +28,7 @@
         /**
          * {@inheritdoc}
          */
-        public function handle(Configuration $config)
+        public function handle(Configuration $config, array $data)
         {
             // Write extensions folder
             if (!is_dir(EXTENSIONS)) {

--- a/install/Steps/EnableExtensions.php
+++ b/install/Steps/EnableExtensions.php
@@ -1,0 +1,61 @@
+<?php
+
+    use \Psr\Log\LoggerInterface;
+
+    class EnableExtensions implements Step
+    {
+        /**
+         * @var LoggerInterface
+         */
+        protected $logger;
+
+        /**
+         * CreateManifest constructor.
+         *
+         * @param LoggerInterface $logger
+         */
+        public function __construct(LoggerInterface $logger)
+        {
+            $this->logger = $logger;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function handle(Configuration $config)
+        {
+            // Write extensions folder
+            if (!is_dir(EXTENSIONS)) {
+                // Create extensions folder
+                $this->logger->info('WRITING: Creating ‘extensions’ folder (/extensions)');
+                if (!General::realiseDirectory(EXTENSIONS, $config->get('write_mode', 'directory'))) {
+                    throw new Exception('Could not create ‘extension’ directory. Check permission on the root folder.');
+                }
+
+                return true;
+            }
+
+            // Install existing extensions
+            $this->logger->info('CONFIGURING: Installing existing extensions');
+            foreach (new DirectoryIterator(EXTENSIONS) as $e) {
+                if ($e->isDot() || $e->isFile() || !is_file($e->getRealPath() . '/extension.driver.php')) {
+                    continue;
+                }
+
+                $handle = $e->getBasename();
+                try {
+                    if (!ExtensionManager::enable($handle)) {
+                        $this->logger->warning('Could not enable the extension ‘' . $handle . '’.');
+                    }
+                } catch (Exception $ex) {
+                    $this->logger->warning(sprintf(
+                        'Could not enable the extension ‘%s’. %s',
+                        $handle,
+                        $ex->getMessage()
+                    ));
+                }
+            }
+
+            return true;
+        }
+    }

--- a/install/Steps/EnableExtensions.php
+++ b/install/Steps/EnableExtensions.php
@@ -1,12 +1,12 @@
 <?php
     namespace SymphonyCms\Installer\Steps;
 
-    use \Psr\Log\LoggerInterface;
     use Configuration;
-    use General;
-    use Exception;
     use DirectoryIterator;
+    use Exception;
     use ExtensionManager;
+    use General;
+    use Psr\Log\LoggerInterface;
 
     class EnableExtensions implements Step
     {

--- a/install/Steps/EnableLanguage.php
+++ b/install/Steps/EnableLanguage.php
@@ -1,0 +1,45 @@
+<?php
+
+    use \Psr\Log\LoggerInterface;
+
+    class EnableLanguage implements Step
+    {
+        /**
+         * @var LoggerInterface
+         */
+        protected $logger;
+
+        /**
+         * EnableLanguage constructor.
+         *
+         * @param LoggerInterface $logger
+         */
+        public function __construct(LoggerInterface $logger)
+        {
+            $this->logger = $logger;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function handle(Configuration $config)
+        {
+            // Loading default language
+            if (isset($_REQUEST['lang']) && $_REQUEST['lang'] !== 'en') {
+                $this->logger->info('CONFIGURING: Default language');
+
+                $language = Lang::Languages();
+                $language = $language[$_REQUEST['lang']];
+
+                // Is the language extension enabled?
+                if (in_array('lang_' . $language['handle'], ExtensionManager::listInstalledHandles())) {
+                    $config->set('lang', $_REQUEST['lang'], 'symphony');
+                } else {
+                    $this->logger->warning('Could not enable the desired language ‘' . $language['name'] . '’.');
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }

--- a/install/Steps/EnableLanguage.php
+++ b/install/Steps/EnableLanguage.php
@@ -1,33 +1,33 @@
 <?php
-    namespace SymphonyCms\Installer\Steps;
+namespace SymphonyCms\Installer\Steps;
 
-    use Configuration;
-    use ExtensionManager;
-    use Lang;
+use Configuration;
+use ExtensionManager;
+use Lang;
 
-    class EnableLanguage extends DefaultStep
+class EnableLanguage extends DefaultStep
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Configuration $config, array $data)
     {
-        /**
-         * {@inheritdoc}
-         */
-        public function handle(Configuration $config, array $data)
-        {
-            // Loading default language
-            if (isset($_REQUEST['lang']) && $_REQUEST['lang'] !== 'en') {
-                $this->logger->info('CONFIGURING: Default language');
+        // Loading default language
+        if (isset($_REQUEST['lang']) && $_REQUEST['lang'] !== 'en') {
+            $this->logger->info('CONFIGURING: Default language');
 
-                $language = Lang::Languages();
-                $language = $language[$_REQUEST['lang']];
+            $language = Lang::Languages();
+            $language = $language[$_REQUEST['lang']];
 
-                // Is the language extension enabled?
-                if (in_array('lang_' . $language['handle'], ExtensionManager::listInstalledHandles())) {
-                    $config->set('lang', $_REQUEST['lang'], 'symphony');
-                } else {
-                    $this->logger->warning('Could not enable the desired language ‘' . $language['name'] . '’.');
-                    return false;
-                }
+            // Is the language extension enabled?
+            if (in_array('lang_' . $language['handle'], ExtensionManager::listInstalledHandles())) {
+                $config->set('lang', $_REQUEST['lang'], 'symphony');
+            } else {
+                $this->logger->warning('Could not enable the desired language ‘' . $language['name'] . '’.');
+                return false;
             }
-
-            return true;
         }
+
+        return true;
     }
+}

--- a/install/Steps/EnableLanguage.php
+++ b/install/Steps/EnableLanguage.php
@@ -1,10 +1,10 @@
 <?php
     namespace SymphonyCms\Installer\Steps;
 
-    use \Psr\Log\LoggerInterface;
     use Configuration;
-    use Lang;
     use ExtensionManager;
+    use Lang;
+    use Psr\Log\LoggerInterface;
 
     class EnableLanguage implements Step
     {

--- a/install/Steps/EnableLanguage.php
+++ b/install/Steps/EnableLanguage.php
@@ -1,6 +1,10 @@
 <?php
+    namespace SymphonyCms\Installer\Steps;
 
     use \Psr\Log\LoggerInterface;
+    use Configuration;
+    use Lang;
+    use ExtensionManager;
 
     class EnableLanguage implements Step
     {
@@ -22,7 +26,7 @@
         /**
          * {@inheritdoc}
          */
-        public function handle(Configuration $config)
+        public function handle(Configuration $config, array $data)
         {
             // Loading default language
             if (isset($_REQUEST['lang']) && $_REQUEST['lang'] !== 'en') {

--- a/install/Steps/EnableLanguage.php
+++ b/install/Steps/EnableLanguage.php
@@ -4,25 +4,9 @@
     use Configuration;
     use ExtensionManager;
     use Lang;
-    use Psr\Log\LoggerInterface;
 
-    class EnableLanguage implements Step
+    class EnableLanguage extends DefaultStep
     {
-        /**
-         * @var LoggerInterface
-         */
-        protected $logger;
-
-        /**
-         * EnableLanguage constructor.
-         *
-         * @param LoggerInterface $logger
-         */
-        public function __construct(LoggerInterface $logger)
-        {
-            $this->logger = $logger;
-        }
-
         /**
          * {@inheritdoc}
          */

--- a/install/Steps/ImportWorkspace.php
+++ b/install/Steps/ImportWorkspace.php
@@ -4,35 +4,17 @@
     use Configuration;
     use DatabaseException;
     use Exception;
-    use Psr\Log\LoggerInterface;
     use Symphony;
 
-    class ImportWorkspace implements Step
+    class ImportWorkspace extends DefaultStep
     {
-        /**
-         * @var LoggerInterface
-         */
-        protected $logger;
-
-        /**
-         * CreateManifest constructor.
-         *
-         * @param LoggerInterface $logger
-         */
-        public function __construct(LoggerInterface $logger)
-        {
-            $this->logger = $logger;
-        }
-
         /**
          * {@inheritdoc}
          */
         public function handle(Configuration $config, array $data)
         {
-            $this->logger->info('An existing ‘workspace’ directory was found at this location. Symphony will use this workspace.');
-
             // MySQL: Importing workspace data
-            $this->logger->info('MYSQL: Importing Workspace Data...');
+            $this->logger->info('MYSQL: Importing existing workspace data');
 
             if (is_file(WORKSPACE . '/install.sql')) {
                 try {

--- a/install/Steps/ImportWorkspace.php
+++ b/install/Steps/ImportWorkspace.php
@@ -1,0 +1,46 @@
+<?php
+
+    use \Psr\Log\LoggerInterface;
+
+    class ImportWorkspace implements Step
+    {
+        /**
+         * @var LoggerInterface
+         */
+        protected $logger;
+
+        /**
+         * CreateManifest constructor.
+         *
+         * @param LoggerInterface $logger
+         */
+        public function __construct(LoggerInterface $logger)
+        {
+            $this->logger = $logger;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function handle(Configuration $config)
+        {
+            $this->logger->info('An existing ‘workspace’ directory was found at this location. Symphony will use this workspace.');
+
+            // MySQL: Importing workspace data
+            $this->logger->info('MYSQL: Importing Workspace Data...');
+
+            if (is_file(WORKSPACE . '/install.sql')) {
+                try {
+                    Symphony::Database()->import(file_get_contents(WORKSPACE . '/install.sql'));
+                } catch (DatabaseException $e) {
+                    throw new Exception(sprintf(
+                        'There was an error while trying to import data to the database. MySQL returned: %s:%s',
+                        $e->getDatabaseErrorCode(),
+                        $e->getDatabaseErrorMessage()
+                    ));
+                }
+            }
+
+            return true;
+        }
+    }

--- a/install/Steps/ImportWorkspace.php
+++ b/install/Steps/ImportWorkspace.php
@@ -1,33 +1,33 @@
 <?php
-    namespace SymphonyCms\Installer\Steps;
+namespace SymphonyCms\Installer\Steps;
 
-    use Configuration;
-    use DatabaseException;
-    use Exception;
-    use Symphony;
+use Configuration;
+use DatabaseException;
+use Exception;
+use Symphony;
 
-    class ImportWorkspace extends DefaultStep
+class ImportWorkspace extends DefaultStep
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Configuration $config, array $data)
     {
-        /**
-         * {@inheritdoc}
-         */
-        public function handle(Configuration $config, array $data)
-        {
-            // MySQL: Importing workspace data
-            $this->logger->info('MYSQL: Importing existing workspace data');
+        // MySQL: Importing workspace data
+        $this->logger->info('MYSQL: Importing existing workspace data');
 
-            if (is_file(WORKSPACE . '/install.sql')) {
-                try {
-                    Symphony::Database()->import(file_get_contents(WORKSPACE . '/install.sql'));
-                } catch (DatabaseException $e) {
-                    throw new Exception(sprintf(
-                        'There was an error while trying to import data to the database. MySQL returned: %s:%s',
-                        $e->getDatabaseErrorCode(),
-                        $e->getDatabaseErrorMessage()
-                    ));
-                }
+        if (is_file(WORKSPACE . '/install.sql')) {
+            try {
+                Symphony::Database()->import(file_get_contents(WORKSPACE . '/install.sql'));
+            } catch (DatabaseException $e) {
+                throw new Exception(sprintf(
+                    'There was an error while trying to import data to the database. MySQL returned: %s:%s',
+                    $e->getDatabaseErrorCode(),
+                    $e->getDatabaseErrorMessage()
+                ));
             }
-
-            return true;
         }
+
+        return true;
     }
+}

--- a/install/Steps/ImportWorkspace.php
+++ b/install/Steps/ImportWorkspace.php
@@ -1,6 +1,11 @@
 <?php
+    namespace SymphonyCms\Installer\Steps;
 
     use \Psr\Log\LoggerInterface;
+    use Configuration;
+    use Symphony;
+    use DatabaseException;
+    use Exception;
 
     class ImportWorkspace implements Step
     {
@@ -22,7 +27,7 @@
         /**
          * {@inheritdoc}
          */
-        public function handle(Configuration $config)
+        public function handle(Configuration $config, array $data)
         {
             $this->logger->info('An existing ‘workspace’ directory was found at this location. Symphony will use this workspace.');
 

--- a/install/Steps/ImportWorkspace.php
+++ b/install/Steps/ImportWorkspace.php
@@ -1,11 +1,11 @@
 <?php
     namespace SymphonyCms\Installer\Steps;
 
-    use \Psr\Log\LoggerInterface;
     use Configuration;
-    use Symphony;
     use DatabaseException;
     use Exception;
+    use Psr\Log\LoggerInterface;
+    use Symphony;
 
     class ImportWorkspace implements Step
     {

--- a/install/Steps/Step.php
+++ b/install/Steps/Step.php
@@ -1,0 +1,10 @@
+<?php
+
+    interface Step
+    {
+        /**
+         * @param Configuration $config
+         * @return mixed
+         */
+        public function handle(Configuration $config);
+    }

--- a/install/Steps/Step.php
+++ b/install/Steps/Step.php
@@ -1,10 +1,14 @@
 <?php
+    namespace SymphonyCms\Installer\Steps;
+
+    use Configuration;
 
     interface Step
     {
         /**
          * @param Configuration $config
+         * @param array $data
          * @return mixed
          */
-        public function handle(Configuration $config);
+        public function handle(Configuration $config, array $data);
     }

--- a/install/Steps/Step.php
+++ b/install/Steps/Step.php
@@ -1,24 +1,24 @@
 <?php
-    namespace SymphonyCms\Installer\Steps;
+namespace SymphonyCms\Installer\Steps;
 
-    use Configuration;
+use Configuration;
 
-    interface Step
-    {
-        /**
-         * Allow the step to take actions to override an existing installation.
-         *
-         * @param boolean $override
-         * @return $this
-         */
-        public function setOverride($override = false);
+interface Step
+{
+    /**
+     * Allow the step to take actions to override an existing installation.
+     *
+     * @param boolean $override
+     * @return $this
+     */
+    public function setOverride($override = false);
 
-        /**
-         * Given `$config` and additional data captured from the user, run this step.
-         *
-         * @param Configuration $config
-         * @param array $data
-         * @return mixed
-         */
-        public function handle(Configuration $config, array $data);
-    }
+    /**
+     * Given `$config` and additional data captured from the user, run this step.
+     *
+     * @param Configuration $config
+     * @param array $data
+     * @return mixed
+     */
+    public function handle(Configuration $config, array $data);
+}

--- a/install/Steps/Step.php
+++ b/install/Steps/Step.php
@@ -6,6 +6,16 @@
     interface Step
     {
         /**
+         * Allow the step to take actions to override an existing installation.
+         *
+         * @param boolean $override
+         * @return $this
+         */
+        public function setOverride($override = false);
+
+        /**
+         * Given `$config` and additional data captured from the user, run this step.
+         *
          * @param Configuration $config
          * @param array $data
          * @return mixed

--- a/install/Steps/Workspace.php
+++ b/install/Steps/Workspace.php
@@ -2,31 +2,15 @@
     namespace SymphonyCms\Installer\Steps;
 
     use Configuration;
-    use Psr\Log\LoggerInterface;
 
-    class Workspace implements Step
+    class Workspace extends DefaultStep
     {
-        /**
-         * @var LoggerInterface
-         */
-        protected $logger;
-
-        /**
-         * CreateManifest constructor.
-         *
-         * @param LoggerInterface $logger
-         */
-        public function __construct(LoggerInterface $logger)
-        {
-            $this->logger = $logger;
-        }
-
         /**
          * {@inheritdoc}
          */
         public function handle(Configuration $config, array $data)
         {
-            if (!is_dir(DOCROOT . '/workspace')) {
+            if (!is_dir(WORKSPACE)) {
                 return (new CreateWorkspace($this->logger))->handle($config, $data);
             } else {
                 return (new ImportWorkspace($this->logger))->handle($config, $data);

--- a/install/Steps/Workspace.php
+++ b/install/Steps/Workspace.php
@@ -1,19 +1,19 @@
 <?php
-    namespace SymphonyCms\Installer\Steps;
+namespace SymphonyCms\Installer\Steps;
 
-    use Configuration;
+use Configuration;
 
-    class Workspace extends DefaultStep
+class Workspace extends DefaultStep
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Configuration $config, array $data)
     {
-        /**
-         * {@inheritdoc}
-         */
-        public function handle(Configuration $config, array $data)
-        {
-            if (!is_dir(WORKSPACE)) {
-                return (new CreateWorkspace($this->logger))->handle($config, $data);
-            } else {
-                return (new ImportWorkspace($this->logger))->handle($config, $data);
-            }
+        if (!is_dir(WORKSPACE)) {
+            return (new CreateWorkspace($this->logger))->handle($config, $data);
+        } else {
+            return (new ImportWorkspace($this->logger))->handle($config, $data);
         }
     }
+}

--- a/install/Steps/Workspace.php
+++ b/install/Steps/Workspace.php
@@ -1,0 +1,33 @@
+<?php
+
+    use \Psr\Log\LoggerInterface;
+
+    class Workspace implements Step
+    {
+        /**
+         * @var LoggerInterface
+         */
+        protected $logger;
+
+        /**
+         * CreateManifest constructor.
+         *
+         * @param LoggerInterface $logger
+         */
+        public function __construct(LoggerInterface $logger)
+        {
+            $this->logger = $logger;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function handle(Configuration $config)
+        {
+            if (!is_dir(DOCROOT . '/workspace')) {
+                return (new CreateWorkspace($this->logger))->handle($config);
+            } else {
+                return (new ImportWorkspace($this->logger))->handle($config);
+            }
+        }
+    }

--- a/install/Steps/Workspace.php
+++ b/install/Steps/Workspace.php
@@ -1,6 +1,8 @@
 <?php
+    namespace SymphonyCms\Installer\Steps;
 
     use \Psr\Log\LoggerInterface;
+    use Configuration;
 
     class Workspace implements Step
     {
@@ -22,12 +24,12 @@
         /**
          * {@inheritdoc}
          */
-        public function handle(Configuration $config)
+        public function handle(Configuration $config, array $data)
         {
             if (!is_dir(DOCROOT . '/workspace')) {
-                return (new CreateWorkspace($this->logger))->handle($config);
+                return (new CreateWorkspace($this->logger))->handle($config, $data);
             } else {
-                return (new ImportWorkspace($this->logger))->handle($config);
+                return (new ImportWorkspace($this->logger))->handle($config, $data);
             }
         }
     }

--- a/install/Steps/Workspace.php
+++ b/install/Steps/Workspace.php
@@ -1,8 +1,8 @@
 <?php
     namespace SymphonyCms\Installer\Steps;
 
-    use \Psr\Log\LoggerInterface;
     use Configuration;
+    use Psr\Log\LoggerInterface;
 
     class Workspace implements Step
     {

--- a/install/command/InstallCommand.php
+++ b/install/command/InstallCommand.php
@@ -3,8 +3,15 @@
     namespace SymphonyCms\Installer\Command;
 
     use Symfony\Component\Console\Command\Command;
+    use Symfony\Component\Console\Input\ArrayInput;
+    use Symfony\Component\Console\Input\InputArgument;
     use Symfony\Component\Console\Input\InputInterface;
+    use Symfony\Component\Console\Input\InputOption;
+    use Symfony\Component\Console\Logger\ConsoleLogger;
     use Symfony\Component\Console\Output\OutputInterface;
+    use Symfony\Component\Console\Question\ConfirmationQuestion;
+    use SymphonyCms\Installer\Lib\ConsoleInstaller;
+    use Configuration;
 
     class InstallCommmand extends Command
     {
@@ -12,12 +19,65 @@
         {
             $this
                 ->setName('install')
-                ->setDescription('Install Symphony given a configuration file');
+                ->setDescription('Install Symphony on this server.')
+                ->addArgument('config', InputArgument::REQUIRED, 'Path to Symphony configuration file.')
+                ->addOption('override', 'o', InputOption::VALUE_NONE, 'Whether the Installer shall override an existing Symphony install.')
             ;
         }
 
         protected function execute(InputInterface $input, OutputInterface $output)
         {
-            // Make me work :)
+            // Be really sure..
+            if ($input->getOption('override') && !$input->getOption('no-interaction')) {
+                $helper = $this->getHelper('question');
+                $question = new ConfirmationQuestion('Are you sure you want to overwrite the existing Symphony installation?', false);
+
+                if (!$helper->ask($input, $output, $question)) {
+                    $output->writeln('<comment>Skipping Symphony installation</comment>');
+                    return 0;
+                } else {
+                    $output->writeln('<info>Overwriting existing Symphony installation</info>');
+                }
+            }
+
+            // First, check the requirements.
+            $command = $this->getApplication()->find('requirements');
+            $requirementsInput = new ArrayInput([]);
+            if ($command->run($requirementsInput, $output) !== 0) {
+                return 1;
+            }
+
+            // Verify Configuration File is readable
+            $configFile = $input->getArgument('config');
+            if (!is_readable($configFile)) {
+                $output->writeln('<error>Unable to install Symphony, configuration file is unreadable.</error>');
+                return 1;
+            } else {
+                $config = new Configuration();
+                $config->setArray(require_once $configFile);
+            }
+
+            $logger = new ConsoleLogger($output);
+            $installer = new ConsoleInstaller($logger, $config);
+            $installer->setOverride($input->getOption('override'));
+
+            // TODO: Ask the user.
+            $data = [
+                'user' => [
+                    'firstname' => 'Brendan',
+                    'lastname' => 'Abbott',
+                    'username' => 'brendan',
+                    'password' => 'testing',
+                    'email' => 'brendan@bloodbone.ws'
+                ]
+            ];
+
+            if (!$installer->install($data)) {
+                $output->writeln('<error>Symphony has been installed as there was an error.</error>');
+                return 1;
+            }
+
+            $output->writeln('<info>Symphony has been installed successfully.</info>');
+            return 0;
         }
     }

--- a/install/command/InstallCommand.php
+++ b/install/command/InstallCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+    namespace SymphonyCms\Installer\Command;
+
+    use Symfony\Component\Console\Command\Command;
+    use Symfony\Component\Console\Input\InputInterface;
+    use Symfony\Component\Console\Output\OutputInterface;
+
+    class InstallCommmand extends Command
+    {
+        protected function configure()
+        {
+            $this
+                ->setName('install')
+                ->setDescription('Install Symphony given a configuration file');
+            ;
+        }
+
+        protected function execute(InputInterface $input, OutputInterface $output)
+        {
+            // Make me work :)
+        }
+    }

--- a/install/command/InstallCommand.php
+++ b/install/command/InstallCommand.php
@@ -64,11 +64,11 @@
             // TODO: Ask the user.
             $data = [
                 'user' => [
-                    'firstname' => 'Brendan',
-                    'lastname' => 'Abbott',
-                    'username' => 'brendan',
+                    'firstname' => 'Test',
+                    'lastname' => 'User',
+                    'username' => 'symphony',
                     'password' => 'testing',
-                    'email' => 'brendan@bloodbone.ws'
+                    'email' => 'team@getsymphony.com'
                 ]
             ];
 

--- a/install/command/InstallCommand.php
+++ b/install/command/InstallCommand.php
@@ -1,85 +1,85 @@
 <?php
 
-    namespace SymphonyCms\Installer\Command;
+namespace SymphonyCms\Installer\Command;
 
-    use Symfony\Component\Console\Command\Command;
-    use Symfony\Component\Console\Input\ArrayInput;
-    use Symfony\Component\Console\Input\InputArgument;
-    use Symfony\Component\Console\Input\InputInterface;
-    use Symfony\Component\Console\Input\InputOption;
-    use Symfony\Component\Console\Logger\ConsoleLogger;
-    use Symfony\Component\Console\Output\OutputInterface;
-    use Symfony\Component\Console\Question\ConfirmationQuestion;
-    use SymphonyCms\Installer\Lib\ConsoleInstaller;
-    use Configuration;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use SymphonyCms\Installer\Lib\ConsoleInstaller;
+use Configuration;
 
-    class InstallCommand extends Command
+class InstallCommand extends Command
+{
+    protected function configure()
     {
-        protected function configure()
-        {
-            $this
-                ->setName('install')
-                ->setDescription('Install Symphony on this server.')
-                ->addArgument('config', InputArgument::REQUIRED, 'Path to Symphony configuration file.')
-                ->addOption('override', 'o', InputOption::VALUE_NONE, 'Whether the Installer shall override an existing Symphony install.')
-            ;
-        }
-
-        protected function execute(InputInterface $input, OutputInterface $output)
-        {
-            // Be really sure..
-            if ($input->getOption('override') && !$input->getOption('no-interaction')) {
-                $helper = $this->getHelper('question');
-                $question = new ConfirmationQuestion('Are you sure you want to overwrite the existing Symphony installation?', false);
-
-                if (!$helper->ask($input, $output, $question)) {
-                    $output->writeln('<comment>Skipping Symphony installation</comment>');
-                    return 0;
-                } else {
-                    $output->writeln('<info>Overwriting existing Symphony installation</info>');
-                }
-            }
-
-            // First, check the requirements.
-            $command = $this->getApplication()->find('requirements');
-            $requirementsInput = new ArrayInput([]);
-            if ($command->run($requirementsInput, $output) !== 0) {
-                return 1;
-            }
-
-            // Verify Configuration File is readable
-            $configFile = $input->getArgument('config');
-            if (!is_readable($configFile)) {
-                $output->writeln('<error>Unable to install Symphony, configuration file is unreadable.</error>');
-                return 1;
-            } else {
-                $config = new Configuration();
-                $config->setArray(require_once $configFile);
-            }
-
-            $logger = new ConsoleLogger($output);
-            $installer = new ConsoleInstaller($logger, $config);
-            $installer->setOverride($input->getOption('override'));
-
-            // TODO: Ask the user.
-            $data = [
-                'user' => [
-                    'firstname' => 'Test',
-                    'lastname' => 'User',
-                    'username' => 'symphony',
-                    'password' => 'testing',
-                    'email' => 'team@getsymphony.com'
-                ]
-            ];
-
-            if (!$installer->install($data)) {
-                $output->writeln('<error>Symphony has been installed as there was an error.</error>');
-                return 1;
-            }
-
-            $output->writeln('<info>Symphony has been installed successfully.</info>');
-            return 0;
-        }
+        $this
+            ->setName('install')
+            ->setDescription('Install Symphony on this server.')
+            ->addArgument('config', InputArgument::REQUIRED, 'Path to Symphony configuration file.')
+            ->addOption('override', 'o', InputOption::VALUE_NONE, 'Whether the Installer shall override an existing Symphony install.')
+        ;
     }
 
-    return __NAMESPACE__;
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // Be really sure..
+        if ($input->getOption('override') && !$input->getOption('no-interaction')) {
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion('Are you sure you want to overwrite the existing Symphony installation?', false);
+
+            if (!$helper->ask($input, $output, $question)) {
+                $output->writeln('<comment>Skipping Symphony installation</comment>');
+                return 0;
+            } else {
+                $output->writeln('<info>Overwriting existing Symphony installation</info>');
+            }
+        }
+
+        // First, check the requirements.
+        $command = $this->getApplication()->find('requirements');
+        $requirementsInput = new ArrayInput([]);
+        if ($command->run($requirementsInput, $output) !== 0) {
+            return 1;
+        }
+
+        // Verify Configuration File is readable
+        $configFile = $input->getArgument('config');
+        if (!is_readable($configFile)) {
+            $output->writeln('<error>Unable to install Symphony, configuration file is unreadable.</error>');
+            return 1;
+        } else {
+            $config = new Configuration();
+            $config->setArray(require_once $configFile);
+        }
+
+        $logger = new ConsoleLogger($output);
+        $installer = new ConsoleInstaller($logger, $config);
+        $installer->setOverride($input->getOption('override'));
+
+        // TODO: Ask the user.
+        $data = [
+            'user' => [
+                'firstname' => 'Test',
+                'lastname' => 'User',
+                'username' => 'symphony',
+                'password' => 'testing',
+                'email' => 'team@getsymphony.com'
+            ]
+        ];
+
+        if (!$installer->install($data)) {
+            $output->writeln('<error>Symphony has been installed as there was an error.</error>');
+            return 1;
+        }
+
+        $output->writeln('<info>Symphony has been installed successfully.</info>');
+        return 0;
+    }
+}
+
+return __NAMESPACE__;

--- a/install/command/InstallCommand.php
+++ b/install/command/InstallCommand.php
@@ -13,7 +13,7 @@
     use SymphonyCms\Installer\Lib\ConsoleInstaller;
     use Configuration;
 
-    class InstallCommmand extends Command
+    class InstallCommand extends Command
     {
         protected function configure()
         {
@@ -81,3 +81,5 @@
             return 0;
         }
     }
+
+    return __NAMESPACE__;

--- a/install/command/RequirementsCommand.php
+++ b/install/command/RequirementsCommand.php
@@ -12,7 +12,7 @@
         protected function configure()
         {
             $this
-                ->setName('check')
+                ->setName('requirements')
                 ->setDescription('Check if this server is capable of installing Symphony.')
             ;
         }
@@ -22,12 +22,17 @@
             $requirements = new Requirements();
             $errors = $requirements->check();
 
-            if (empty($errors)) {
-                $output->writeln('All good, the show goes on');
-            } else {
+            if (!empty($errors)) {
+                $output->writeln('<error>Fail.</error> Unfortunately this server does not support Symphony CMS:');
                 foreach ($errors as $error) {
                     $output->writeln($error['msg'] . ' ' . $error['details']);
                 }
+
+                return 1;
             }
+
+            $output->writeln('<info>Pass.</info> The server supports the minimum requirements for Symphony CMS.');
+
+            return 0;
         }
     }

--- a/install/command/RequirementsCommand.php
+++ b/install/command/RequirementsCommand.php
@@ -1,40 +1,40 @@
 <?php
 
-    namespace SymphonyCms\Installer\Command;
+namespace SymphonyCms\Installer\Command;
 
-    use Symfony\Component\Console\Command\Command;
-    use Symfony\Component\Console\Input\InputInterface;
-    use Symfony\Component\Console\Output\OutputInterface;
-    use SymphonyCms\Installer\Lib\Requirements;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use SymphonyCms\Installer\Lib\Requirements;
 
-    class RequirementsCommand extends Command
+class RequirementsCommand extends Command
+{
+    protected function configure()
     {
-        protected function configure()
-        {
-            $this
-                ->setName('requirements')
-                ->setDescription('Check if this server is capable of installing Symphony.')
-            ;
-        }
-
-        protected function execute(InputInterface $input, OutputInterface $output)
-        {
-            $requirements = new Requirements();
-            $errors = $requirements->check();
-
-            if (!empty($errors)) {
-                $output->writeln('<error>Fail.</error> Unfortunately this server does not support Symphony CMS:');
-                foreach ($errors as $error) {
-                    $output->writeln($error['msg'] . ' ' . $error['details']);
-                }
-
-                return 1;
-            }
-
-            $output->writeln('<info>Pass.</info> The server supports the minimum requirements for Symphony CMS.');
-
-            return 0;
-        }
+        $this
+            ->setName('requirements')
+            ->setDescription('Check if this server is capable of installing Symphony.')
+        ;
     }
 
-    return __NAMESPACE__;
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $requirements = new Requirements();
+        $errors = $requirements->check();
+
+        if (!empty($errors)) {
+            $output->writeln('<error>Fail.</error> Unfortunately this server does not support Symphony CMS:');
+            foreach ($errors as $error) {
+                $output->writeln($error['msg'] . ' ' . $error['details']);
+            }
+
+            return 1;
+        }
+
+        $output->writeln('<info>Pass.</info> The server supports the minimum requirements for Symphony CMS.');
+
+        return 0;
+    }
+}
+
+return __NAMESPACE__;

--- a/install/command/RequirementsCommand.php
+++ b/install/command/RequirementsCommand.php
@@ -7,7 +7,7 @@
     use Symfony\Component\Console\Output\OutputInterface;
     use SymphonyCms\Installer\Lib\Requirements;
 
-    class RequirementsCommmand extends Command
+    class RequirementsCommand extends Command
     {
         protected function configure()
         {
@@ -36,3 +36,5 @@
             return 0;
         }
     }
+
+    return __NAMESPACE__;

--- a/install/command/RequirementsCommand.php
+++ b/install/command/RequirementsCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+    namespace SymphonyCms\Installer\Command;
+
+    use Symfony\Component\Console\Command\Command;
+    use Symfony\Component\Console\Input\InputInterface;
+    use Symfony\Component\Console\Output\OutputInterface;
+    use SymphonyCms\Installer\Lib\Requirements;
+
+    class RequirementsCommmand extends Command
+    {
+        protected function configure()
+        {
+            $this
+                ->setName('check')
+                ->setDescription('Check if this server is capable of installing Symphony.')
+            ;
+        }
+
+        protected function execute(InputInterface $input, OutputInterface $output)
+        {
+            $requirements = new Requirements();
+            $errors = $requirements->check();
+
+            if (empty($errors)) {
+                $output->writeln('All good, the show goes on');
+            } else {
+                foreach ($errors as $error) {
+                    $output->writeln($error['msg'] . ' ' . $error['details']);
+                }
+            }
+        }
+    }

--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -30,10 +30,7 @@
                 'class' => '\Monolog\Handler\StreamHandler',
                 'args' => array(
                     '{vars.filename}',
-                    100,
-                    true,
-                    '{file.write_mode}',
-                    false
+                    100
                 )
             ),
             'formatter' => array(

--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -1,119 +1,119 @@
 <?php
-    return $settings = array(
+return $settings = array(
 
 
-        ###### ADMIN ######
-        'admin' => array(
-            'max_upload_size' => '5242880',
-            'upload_blacklist' => '/\.(?:php[34567s]?|phtml)$/i',
-        ),
-        ########
+    ###### ADMIN ######
+    'admin' => array(
+        'max_upload_size' => '5242880',
+        'upload_blacklist' => '/\.(?:php[34567s]?|phtml)$/i',
+    ),
+    ########
 
 
-        ###### SYMPHONY ######
-        'symphony' => array(
-            'admin-path' => 'symphony',
-            'pagination_maximum_rows' => '20',
-            'association_maximum_rows' => '5',
-            'lang' => 'en',
-            'pages_table_nest_children' => 'no',
-            'version' => VERSION,
-            'cell_truncation_length' => '75',
-            'enable_xsrf' => 'yes',
-        ),
-        ########
+    ###### SYMPHONY ######
+    'symphony' => array(
+        'admin-path' => 'symphony',
+        'pagination_maximum_rows' => '20',
+        'association_maximum_rows' => '5',
+        'lang' => 'en',
+        'pages_table_nest_children' => 'no',
+        'version' => VERSION,
+        'cell_truncation_length' => '75',
+        'enable_xsrf' => 'yes',
+    ),
+    ########
 
 
-        ###### LOG ######
-        'log' => array(
-            'handler' => array(
-                'class' => '\Monolog\Handler\StreamHandler',
-                'args' => array(
-                    '{vars.filename}',
-                    100
-                )
-            ),
-            'formatter' => array(
-                'class' => '\Monolog\Formatter\LineFormatter',
-                'args' => array(
-                    '%datetime% > %level_name%: %message% %context% %extra%' . PHP_EOL,
-                    '{region.date_format}{region.datetime_separator}{region.time_format}',
-                    false,
-                    true
-                )
+    ###### LOG ######
+    'log' => array(
+        'handler' => array(
+            'class' => '\Monolog\Handler\StreamHandler',
+            'args' => array(
+                '{vars.filename}',
+                100
             )
         ),
-        ########
+        'formatter' => array(
+            'class' => '\Monolog\Formatter\LineFormatter',
+            'args' => array(
+                '%datetime% > %level_name%: %message% %context% %extra%' . PHP_EOL,
+                '{region.date_format}{region.datetime_separator}{region.time_format}',
+                false,
+                true
+            )
+        )
+    ),
+    ########
 
 
-        ###### DATABASE ######
-        'database' => array(
-            'host' => 'localhost',
-            'port' => '3306',
-            'user' => null,
-            'password' => null,
-            'db' => null,
-            'tbl_prefix' => 'sym_',
-            'query_caching' => 'on',
-            'query_logging' => 'on'
-        ),
-        ########
+    ###### DATABASE ######
+    'database' => array(
+        'host' => 'localhost',
+        'port' => '3306',
+        'user' => null,
+        'password' => null,
+        'db' => null,
+        'tbl_prefix' => 'sym_',
+        'query_caching' => 'on',
+        'query_logging' => 'on'
+    ),
+    ########
 
 
-        ###### SESSION ######
-        'session' => array(
-            'admin_session_name' => 'symphony_admin',
-            'public_session_name' => 'symphony_public',
-            'admin_session_expires' => '2 weeks',
-            'public_session_expires' => '2 weeks',
-            'session_gc_probability' => '1',
-            'session_gc_divisor' => '10'
-        ),
-        ########
+    ###### SESSION ######
+    'session' => array(
+        'admin_session_name' => 'symphony_admin',
+        'public_session_name' => 'symphony_public',
+        'admin_session_expires' => '2 weeks',
+        'public_session_expires' => '2 weeks',
+        'session_gc_probability' => '1',
+        'session_gc_divisor' => '10'
+    ),
+    ########
 
 
-        ###### PUBLIC ######
-        'public' => array(
-            'display_event_xml_in_source' => 'no',
-        ),
-        ########
+    ###### PUBLIC ######
+    'public' => array(
+        'display_event_xml_in_source' => 'no',
+    ),
+    ########
 
 
-        ###### GENERAL ######
-        'general' => array(
-            'sitename' => 'Symphony CMS',
-            'useragent' => 'Symphony/' . VERSION,
-        ),
-        ########
+    ###### GENERAL ######
+    'general' => array(
+        'sitename' => 'Symphony CMS',
+        'useragent' => 'Symphony/' . VERSION,
+    ),
+    ########
 
 
-        ###### FILE ######
-        'file' => array(
-            'write_mode' => '0644',
-        ),
-        ########
+    ###### FILE ######
+    'file' => array(
+        'write_mode' => '0644',
+    ),
+    ########
 
 
-        ###### DIRECTORY ######
-        'directory' => array(
-            'write_mode' => '0755',
-        ),
-        ########
+    ###### DIRECTORY ######
+    'directory' => array(
+        'write_mode' => '0755',
+    ),
+    ########
 
 
-        ###### REGION ######
-        'region' => array(
-            'time_format' => 'g:i a',
-            'date_format' => 'm/d/Y',
-            'datetime_separator' => ' ',
-            'timezone' => null
-        ),
-        ########
+    ###### REGION ######
+    'region' => array(
+        'time_format' => 'g:i a',
+        'date_format' => 'm/d/Y',
+        'datetime_separator' => ' ',
+        'timezone' => null
+    ),
+    ########
 
 
-        ###### CACHE ######
-        'cache_driver' => array(
-            'default' => 'database',
-        ),
-        ########
-    );
+    ###### CACHE ######
+    'cache_driver' => array(
+        'default' => 'database',
+    ),
+    ########
+);

--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -92,14 +92,14 @@
 
         ###### FILE ######
         'file' => array(
-            'write_mode' => 0644,
+            'write_mode' => '0644',
         ),
         ########
 
 
         ###### DIRECTORY ######
         'directory' => array(
-            'write_mode' => 0755,
+            'write_mode' => '0755',
         ),
         ########
 

--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -1,5 +1,5 @@
 <?php
-    $settings = array(
+    return $settings = array(
 
 
         ###### ADMIN ######

--- a/install/includes/config_default.php
+++ b/install/includes/config_default.php
@@ -92,14 +92,14 @@
 
         ###### FILE ######
         'file' => array(
-            'write_mode' => '0644',
+            'write_mode' => 0644,
         ),
         ########
 
 
         ###### DIRECTORY ######
         'directory' => array(
-            'write_mode' => '0755',
+            'write_mode' => 0755,
         ),
         ########
 

--- a/install/index.php
+++ b/install/index.php
@@ -1,4 +1,9 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Installer;
+    use SymphonyCms\Installer\Lib\Updater;
+    use General;
 
     ini_set('display_errors', 1);
 

--- a/install/index.php
+++ b/install/index.php
@@ -1,64 +1,63 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Installer;
-    use SymphonyCms\Installer\Lib\Updater;
-    use General;
+use SymphonyCms\Installer\Lib\Installer;
+use SymphonyCms\Installer\Lib\Updater;
+use General;
 
-    ini_set('display_errors', 1);
+ini_set('display_errors', 1);
 
-    // Set the current timezone, should that not be available default to GMT.
-    if (!date_default_timezone_set(@date_default_timezone_get())) {
-        date_default_timezone_set('GMT');
-    }
+// Set the current timezone, should that not be available default to GMT.
+if (!date_default_timezone_set(@date_default_timezone_get())) {
+    date_default_timezone_set('GMT');
+}
 
-    // Show PHP Info
-    if (isset($_REQUEST['info'])) {
-        return phpinfo();
-    }
+// Show PHP Info
+if (isset($_REQUEST['info'])) {
+    return phpinfo();
+}
 
-    // Defines some constants
-    $clean_url = isset($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : null;
-    $clean_url = dirname(rtrim($_SERVER['PHP_SELF'], $clean_url));
-    $clean_url = rtrim($_SERVER['HTTP_HOST'] . $clean_url, '/\\');
-    $clean_url = preg_replace(array('/\/{2,}/i', '/install$/i'), array('/', null), $clean_url);
-    $clean_url = rtrim($clean_url, '/\\');
-    define('DOMAIN', $clean_url);
+// Defines some constants
+$clean_url = isset($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : null;
+$clean_url = dirname(rtrim($_SERVER['PHP_SELF'], $clean_url));
+$clean_url = rtrim($_SERVER['HTTP_HOST'] . $clean_url, '/\\');
+$clean_url = preg_replace(array('/\/{2,}/i', '/install$/i'), array('/', null), $clean_url);
+$clean_url = rtrim($clean_url, '/\\');
+define('DOMAIN', $clean_url);
 
-    $clean_path = rtrim(__DIR__, '/\\');
-    $clean_path = preg_replace(array('/\/{2,}/i', '/install$/i'), array('/', null), $clean_path);
-    $clean_path = rtrim($clean_path, '/\\');
-    define('DOCROOT', $clean_path);
+$clean_path = rtrim(__DIR__, '/\\');
+$clean_path = preg_replace(array('/\/{2,}/i', '/install$/i'), array('/', null), $clean_path);
+$clean_path = rtrim($clean_path, '/\\');
+define('DOCROOT', $clean_path);
 
-    // Required boot components
-    define('VERSION', '3.0.0-alpha.1');
-    define('INSTALL', DOCROOT . '/install');
+// Required boot components
+define('VERSION', '3.0.0-alpha.1');
+define('INSTALL', DOCROOT . '/install');
 
-    // Include autoloader:
-    require_once DOCROOT . '/vendor/autoload.php';
+// Include autoloader:
+require_once DOCROOT . '/vendor/autoload.php';
 
-    // Include the boot script:
-    require_once DOCROOT . '/symphony/lib/boot/bundle.php';
+// Include the boot script:
+require_once DOCROOT . '/symphony/lib/boot/bundle.php';
 
-    define('INSTALL_LOGS', MANIFEST . '/logs');
-    define('INSTALL_URL', URL . '/install');
+define('INSTALL_LOGS', MANIFEST . '/logs');
+define('INSTALL_URL', URL . '/install');
 
-    // If prompt to remove, delete the entire `/install` directory
-    // and then redirect to Symphony
-    if (isset($_GET['action']) && $_GET['action'] === 'remove') {
-        General::deleteDirectory(INSTALL);
-        redirect(SYMPHONY_URL);
-    }
+// If prompt to remove, delete the entire `/install` directory
+// and then redirect to Symphony
+if (isset($_GET['action']) && $_GET['action'] === 'remove') {
+    General::deleteDirectory(INSTALL);
+    redirect(SYMPHONY_URL);
+}
 
-    // If Symphony is already installed, run the updater
-    if (file_exists(CONFIG)) {
-        // System updater
-        $script = Updater::instance();
-    }
-    // If there's no config file, run the installer
-    else {
-        // System installer
-        $script = Installer::instance();
-    }
+// If Symphony is already installed, run the updater
+if (file_exists(CONFIG)) {
+    // System updater
+    $script = Updater::instance();
+} // If there's no config file, run the installer
+else {
+    // System installer
+    $script = Installer::instance();
+}
 
-    return $script->run();
+return $script->run();

--- a/install/index.php
+++ b/install/index.php
@@ -7,8 +7,7 @@
 
     ini_set('display_errors', 1);
 
-    // Set the current timezone, should that not be available
-    // default to GMT.
+    // Set the current timezone, should that not be available default to GMT.
     if (!date_default_timezone_set(@date_default_timezone_get())) {
         date_default_timezone_set('GMT');
     }
@@ -26,7 +25,7 @@
     $clean_url = rtrim($clean_url, '/\\');
     define('DOMAIN', $clean_url);
 
-    $clean_path = rtrim(dirname(__FILE__), '/\\');
+    $clean_path = rtrim(__DIR__, '/\\');
     $clean_path = preg_replace(array('/\/{2,}/i', '/install$/i'), array('/', null), $clean_path);
     $clean_path = rtrim($clean_path, '/\\');
     define('DOCROOT', $clean_path);

--- a/install/lib/ConsoleInstaller.php
+++ b/install/lib/ConsoleInstaller.php
@@ -1,0 +1,122 @@
+<?php
+
+    namespace SymphonyCms\Installer\Lib;
+
+    use Configuration;
+    use DateTimeObj;
+    use Exception;
+    use Lang;
+    use Psr\Log\LoggerInterface;
+    use Symphony;
+    use SymphonyCms\Installer\Steps;
+
+    class ConsoleInstaller
+    {
+        /**
+         * @var LoggerInterface
+         */
+        protected $logger;
+
+        /**
+         * @var Configuration
+         */
+        protected $configuration;
+
+        /**
+         * @var bool
+         */
+        protected $overwrite = false;
+
+        /**
+         * @param LoggerInterface $logger
+         * @param Configuration $configuration
+         */
+        public function __construct(LoggerInterface $logger, Configuration $configuration)
+        {
+            $this->logger = $logger;
+            $this->configuration = $configuration;
+
+            // Symphony expects a couple of constants to always exist, so lets do a basic bootstrap.
+            $this->bootstrap();
+        }
+
+        /**
+         * Allow the Installer and it's steps to attempt to install Symphony at all costs,
+         * including removing and deleting existing data. Use with caution.
+         *
+         * @param bool $overwrite
+         * @return $this
+         */
+        public function setOverride($overwrite = false)
+        {
+            $this->overwrite = $overwrite;
+
+            return $this;
+        }
+
+        /**
+         * Installs Symphony using the configuration information available.
+         *
+         * @param array $data
+         * @return bool
+         */
+        public function install(array $data)
+        {
+            $steps = [
+                // Create database
+                Steps\CreateDatabase::class,
+                // Create manifest folder structure
+                Steps\CreateManifest::class,
+                // Write .htaccess
+                Steps\CreateHtaccess::class,
+                // Create or import the workspace
+                Steps\Workspace::class,
+                // Enable extensions
+                Steps\EnableExtensions::class
+            ];
+
+            try {
+                foreach ($steps as $step) {
+                    $installStep = new $step($this->logger);
+                    $installStep->setOverride($this->overwrite);
+
+                    if (false === $installStep->handle($this->configuration, $data)) {
+                        throw new Exception(sprintf('Aborting installation, %s step failed.', $step));
+                    }
+                }
+            } catch (Exception $ex) {
+                $this->logger->error($ex->getMessage());
+                return false;
+            }
+
+            if (false === Symphony::Configuration()->write(CONFIG, $this->configuration->get('write_mode', 'file'))) {
+                $this->logger->error('Could not create config file ‘' . CONFIG . '’. Check permission on /manifest.');
+                return false;
+            }
+
+            $this->logger->info('Symphony has been installed.');
+            return true;
+        }
+
+        /**
+         * Bootstrap the environment to the bare minimum for Symphony to 'run'.
+         */
+        private function bootstrap()
+        {
+            // Initialize date/time
+            define_safe('__SYM_DATE_FORMAT__', $this->configuration->get('date_format', 'region'));
+            define_safe('__SYM_TIME_FORMAT__', $this->configuration->get('time_format', 'region'));
+            define_safe('__SYM_DATETIME_FORMAT__',
+                __SYM_DATE_FORMAT__ . $this->configuration->get('datetime_separator', 'region') . __SYM_TIME_FORMAT__);
+            DateTimeObj::setSettings($this->configuration->get('region'));
+
+            Lang::initialize();
+            Symphony::setDatabase();
+            Symphony::initialiseExtensionManager();
+            Symphony::initialiseConfiguration($this->configuration->get());
+
+            define('INSTALL', DOCROOT . '/install');
+            define('INSTALL_LOGS', MANIFEST . '/logs');
+            define('INSTALL_URL', URL . '/install');
+        }
+    }

--- a/install/lib/ConsoleInstaller.php
+++ b/install/lib/ConsoleInstaller.php
@@ -1,122 +1,124 @@
 <?php
 
-    namespace SymphonyCms\Installer\Lib;
+namespace SymphonyCms\Installer\Lib;
 
-    use Configuration;
-    use DateTimeObj;
-    use Exception;
-    use Lang;
-    use Psr\Log\LoggerInterface;
-    use Symphony;
-    use SymphonyCms\Installer\Steps;
+use Configuration;
+use DateTimeObj;
+use Exception;
+use Lang;
+use Psr\Log\LoggerInterface;
+use Symphony;
+use SymphonyCms\Installer\Steps;
 
-    class ConsoleInstaller
+class ConsoleInstaller
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var Configuration
+     */
+    protected $configuration;
+
+    /**
+     * @var bool
+     */
+    protected $overwrite = false;
+
+    /**
+     * @param LoggerInterface $logger
+     * @param Configuration $configuration
+     */
+    public function __construct(LoggerInterface $logger, Configuration $configuration)
     {
-        /**
-         * @var LoggerInterface
-         */
-        protected $logger;
+        $this->logger = $logger;
+        $this->configuration = $configuration;
 
-        /**
-         * @var Configuration
-         */
-        protected $configuration;
-
-        /**
-         * @var bool
-         */
-        protected $overwrite = false;
-
-        /**
-         * @param LoggerInterface $logger
-         * @param Configuration $configuration
-         */
-        public function __construct(LoggerInterface $logger, Configuration $configuration)
-        {
-            $this->logger = $logger;
-            $this->configuration = $configuration;
-
-            // Symphony expects a couple of constants to always exist, so lets do a basic bootstrap.
-            $this->bootstrap();
-        }
-
-        /**
-         * Allow the Installer and it's steps to attempt to install Symphony at all costs,
-         * including removing and deleting existing data. Use with caution.
-         *
-         * @param bool $overwrite
-         * @return $this
-         */
-        public function setOverride($overwrite = false)
-        {
-            $this->overwrite = $overwrite;
-
-            return $this;
-        }
-
-        /**
-         * Installs Symphony using the configuration information available.
-         *
-         * @param array $data
-         * @return bool
-         */
-        public function install(array $data)
-        {
-            $steps = [
-                // Create database
-                Steps\CreateDatabase::class,
-                // Create manifest folder structure
-                Steps\CreateManifest::class,
-                // Write .htaccess
-                Steps\CreateHtaccess::class,
-                // Create or import the workspace
-                Steps\Workspace::class,
-                // Enable extensions
-                Steps\EnableExtensions::class
-            ];
-
-            try {
-                foreach ($steps as $step) {
-                    $installStep = new $step($this->logger);
-                    $installStep->setOverride($this->overwrite);
-
-                    if (false === $installStep->handle($this->configuration, $data)) {
-                        throw new Exception(sprintf('Aborting installation, %s step failed.', $step));
-                    }
-                }
-            } catch (Exception $ex) {
-                $this->logger->error($ex->getMessage());
-                return false;
-            }
-
-            if (false === Symphony::Configuration()->write(CONFIG, $this->configuration->get('write_mode', 'file'))) {
-                $this->logger->error('Could not create config file ‘' . CONFIG . '’. Check permission on /manifest.');
-                return false;
-            }
-
-            $this->logger->info('Symphony has been installed.');
-            return true;
-        }
-
-        /**
-         * Bootstrap the environment to the bare minimum for Symphony to 'run'.
-         */
-        private function bootstrap()
-        {
-            // Initialize date/time
-            define_safe('__SYM_DATE_FORMAT__', $this->configuration->get('date_format', 'region'));
-            define_safe('__SYM_TIME_FORMAT__', $this->configuration->get('time_format', 'region'));
-            define_safe('__SYM_DATETIME_FORMAT__',
-                __SYM_DATE_FORMAT__ . $this->configuration->get('datetime_separator', 'region') . __SYM_TIME_FORMAT__);
-            DateTimeObj::setSettings($this->configuration->get('region'));
-
-            Lang::initialize();
-            Symphony::setDatabase();
-            Symphony::initialiseExtensionManager();
-            Symphony::initialiseConfiguration($this->configuration->get());
-
-            define('INSTALL', DOCROOT . '/install');
-            define('INSTALL_LOGS', MANIFEST . '/logs');
-            define('INSTALL_URL', URL . '/install');
-        }
+        // Symphony expects a couple of constants to always exist, so lets do a basic bootstrap.
+        $this->bootstrap();
     }
+
+    /**
+     * Allow the Installer and it's steps to attempt to install Symphony at all costs,
+     * including removing and deleting existing data. Use with caution.
+     *
+     * @param bool $overwrite
+     * @return $this
+     */
+    public function setOverride($overwrite = false)
+    {
+        $this->overwrite = $overwrite;
+
+        return $this;
+    }
+
+    /**
+     * Installs Symphony using the configuration information available.
+     *
+     * @param array $data
+     * @return bool
+     */
+    public function install(array $data)
+    {
+        $steps = [
+            // Create database
+            Steps\CreateDatabase::class,
+            // Create manifest folder structure
+            Steps\CreateManifest::class,
+            // Write .htaccess
+            Steps\CreateHtaccess::class,
+            // Create or import the workspace
+            Steps\Workspace::class,
+            // Enable extensions
+            Steps\EnableExtensions::class
+        ];
+
+        try {
+            foreach ($steps as $step) {
+                $installStep = new $step($this->logger);
+                $installStep->setOverride($this->overwrite);
+
+                if (false === $installStep->handle($this->configuration, $data)) {
+                    throw new Exception(sprintf('Aborting installation, %s step failed.', $step));
+                }
+            }
+        } catch (Exception $ex) {
+            $this->logger->error($ex->getMessage());
+            return false;
+        }
+
+        if (false === Symphony::Configuration()->write(CONFIG, $this->configuration->get('write_mode', 'file'))) {
+            $this->logger->error('Could not create config file ‘' . CONFIG . '’. Check permission on /manifest.');
+            return false;
+        }
+
+        $this->logger->info('Symphony has been installed.');
+        return true;
+    }
+
+    /**
+     * Bootstrap the environment to the bare minimum for Symphony to 'run'.
+     */
+    private function bootstrap()
+    {
+        // Initialize date/time
+        define_safe('__SYM_DATE_FORMAT__', $this->configuration->get('date_format', 'region'));
+        define_safe('__SYM_TIME_FORMAT__', $this->configuration->get('time_format', 'region'));
+        define_safe(
+            '__SYM_DATETIME_FORMAT__',
+            __SYM_DATE_FORMAT__ . $this->configuration->get('datetime_separator', 'region') . __SYM_TIME_FORMAT__
+        );
+        DateTimeObj::setSettings($this->configuration->get('region'));
+
+        Lang::initialize();
+        Symphony::setDatabase();
+        Symphony::initialiseExtensionManager();
+        Symphony::initialiseConfiguration($this->configuration->get());
+
+        define('INSTALL', DOCROOT . '/install');
+        define('INSTALL_LOGS', MANIFEST . '/logs');
+        define('INSTALL_URL', URL . '/install');
+    }
+}

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1,441 +1,441 @@
 <?php
 
+/**
+ * @package install
+ */
+namespace SymphonyCms\Installer\Lib;
+
+use Administration;
+use DatabaseException;
+use DateTimeObj;
+use Exception;
+use General;
+use GenericErrorHandler;
+use GenericExceptionHandler;
+use Lang;
+use Profiler;
+use Symphony;
+use SymphonyCms\Installer\Steps;
+
+class Installer extends Administration
+{
+    protected static $requirements;
+
     /**
-     * @package install
+     * Override the default Symphony constructor to initialise the Log, Config
+     * and Database objects for installation/update. This allows us to use the
+     * normal accessors.
      */
-    namespace SymphonyCms\Installer\Lib;
-
-    use Administration;
-    use DatabaseException;
-    use DateTimeObj;
-    use Exception;
-    use General;
-    use GenericErrorHandler;
-    use GenericExceptionHandler;
-    use Lang;
-    use Profiler;
-    use Symphony;
-    use SymphonyCms\Installer\Steps;
-
-    class Installer extends Administration
+    protected function __construct()
     {
-        protected static $requirements;
+        self::$Profiler = Profiler::instance();
+        self::$Profiler->sample('Engine Initialisation');
 
-        /**
-         * Override the default Symphony constructor to initialise the Log, Config
-         * and Database objects for installation/update. This allows us to use the
-         * normal accessors.
-         */
-        protected function __construct()
-        {
-            self::$Profiler = Profiler::instance();
-            self::$Profiler->sample('Engine Initialisation');
-
-            if (get_magic_quotes_gpc()) {
-                General::cleanArray($_SERVER);
-                General::cleanArray($_COOKIE);
-                General::cleanArray($_GET);
-                General::cleanArray($_POST);
-            }
-
-            // Include the default Config for installation.
-            static::initialiseConfiguration(require_once(INSTALL . '/includes/config_default.php'));
-
-            // Initialize date/time
-            define_safe('__SYM_DATE_FORMAT__', self::Configuration()->get('date_format', 'region'));
-            define_safe('__SYM_TIME_FORMAT__', self::Configuration()->get('time_format', 'region'));
-            define_safe('__SYM_DATETIME_FORMAT__', __SYM_DATE_FORMAT__ . self::Configuration()->get('datetime_separator', 'region') . __SYM_TIME_FORMAT__);
-            DateTimeObj::setSettings(self::Configuration()->get('region'));
-
-            // Initialize Language, Logs and Database
-            static::initialiseLang();
-            static::initialiseLog(INSTALL_LOGS . '/install');
-            static::initialiseDatabase();
-
-            // Initialize error handlers
-            GenericExceptionHandler::initialise(Symphony::Log());
-            GenericErrorHandler::initialise(Symphony::Log());
-
-            self::$requirements = new Requirements();
+        if (get_magic_quotes_gpc()) {
+            General::cleanArray($_SERVER);
+            General::cleanArray($_COOKIE);
+            General::cleanArray($_GET);
+            General::cleanArray($_POST);
         }
 
-        /**
-         * This function returns an instance of the Installer
-         * class. It is the only way to create a new Installer, as
-         * it implements the Singleton interface
-         *
-         * @return Installer
-         */
-        public static function instance()
-        {
-            if (!(self::$_instance instanceof Installer)) {
-                self::$_instance = new Installer;
-            }
+        // Include the default Config for installation.
+        static::initialiseConfiguration(require_once(INSTALL . '/includes/config_default.php'));
 
-            return self::$_instance;
+        // Initialize date/time
+        define_safe('__SYM_DATE_FORMAT__', self::Configuration()->get('date_format', 'region'));
+        define_safe('__SYM_TIME_FORMAT__', self::Configuration()->get('time_format', 'region'));
+        define_safe(
+            '__SYM_DATETIME_FORMAT__',
+            __SYM_DATE_FORMAT__ . self::Configuration()->get('datetime_separator', 'region') . __SYM_TIME_FORMAT__
+        );
+        DateTimeObj::setSettings(self::Configuration()->get('region'));
+
+        // Initialize Language, Logs and Database
+        static::initialiseLang();
+        static::initialiseLog(INSTALL_LOGS . '/install');
+        static::initialiseDatabase();
+
+        // Initialize error handlers
+        GenericExceptionHandler::initialise(Symphony::Log());
+        GenericErrorHandler::initialise(Symphony::Log());
+
+        self::$requirements = new Requirements();
+    }
+
+    /**
+     * Initialises the language by looking at the `lang` key, passed via GET or POST
+     */
+    public static function initialiseLang()
+    {
+        $lang = !empty($_REQUEST['lang']) ? preg_replace('/[^a-zA-Z\-]/', null, $_REQUEST['lang']) : 'en';
+        Lang::initialize();
+        Lang::set($lang, false);
+    }
+
+    /**
+     * Overrides the default `initialiseLog()` method and writes logs to  `manifest/logs/install`
+     *
+     * @param null $filename
+     * @return boolean|void
+     * @throws Exception
+     */
+    public static function initialiseLog($filename = null)
+    {
+        if (is_dir(INSTALL_LOGS) || General::realiseDirectory(
+            INSTALL_LOGS,
+            self::Configuration()->get('write_mode', 'directory')
+        )
+        ) {
+            return parent::initialiseLog($filename);
         }
 
-        /**
-         * Initialises the language by looking at the `lang` key,
-         * passed via GET or POST
-         */
-        public static function initialiseLang()
-        {
-            $lang = !empty($_REQUEST['lang']) ? preg_replace('/[^a-zA-Z\-]/', null, $_REQUEST['lang']) : 'en';
-            Lang::initialize();
-            Lang::set($lang, false);
+        return;
+    }
+
+    /**
+     * Overrides the default `initialiseDatabase()` method
+     * This allows us to still use the normal accessor
+     */
+    public static function initialiseDatabase()
+    {
+        self::setDatabase();
+    }
+
+    /**
+     * This function returns an instance of the Installer class. It is the only way
+     * to create a new Installer, as it implements the Singleton interface
+     *
+     * @return Installer
+     */
+    public static function instance()
+    {
+        if (!(self::$_instance instanceof Installer)) {
+            self::$_instance = new Installer;
         }
 
-        /**
-         * Overrides the default `initialiseLog()` method and writes
-         * logs to manifest/logs/install
-         *
-         * @param null $filename
-         * @return boolean|void
-         * @throws Exception
-         */
-        public static function initialiseLog($filename = null)
-        {
-            if (is_dir(INSTALL_LOGS) || General::realiseDirectory(INSTALL_LOGS,
-                self::Configuration()->get('write_mode', 'directory'))
-            ) {
-                return parent::initialiseLog($filename);
-            }
+        return self::$_instance;
+    }
 
-            return;
+    public function run()
+    {
+        // Make sure a log file is available
+        if (is_null(Symphony::Log())) {
+            self::__render(new InstallerPage('missing-log'));
         }
 
-        /**
-         * Overrides the default `initialiseDatabase()` method
-         * This allows us to still use the normal accessor
-         */
-        public static function initialiseDatabase()
-        {
-            self::setDatabase();
-        }
+        // Check essential server requirements
+        $errors = self::__checkRequirements();
+        if (!empty($errors)) {
+            Symphony::Log()->error('Installer - Missing requirements.');
 
-        public function run()
-        {
-            // Make sure a log file is available
-            if (is_null(Symphony::Log())) {
-                self::__render(new InstallerPage('missing-log'));
+            foreach ($errors as $err) {
+                Symphony::Log()->error(
+                    sprintf('Requirement - %s', $err['msg'])
+                );
             }
 
-            // Check essential server requirements
-            $errors = self::__checkRequirements();
-            if (!empty($errors)) {
-                Symphony::Log()->error('Installer - Missing requirements.');
-
-                foreach ($errors as $err) {
-                    Symphony::Log()->error(
-                        sprintf('Requirement - %s', $err['msg'])
-                    );
-                }
-
-                self::__render(new InstallerPage('requirements', array(
-                    'errors'=> $errors
-                )));
-            }
-
-            // If language is not set and there is language packs available, show language selection pages
-            if (!isset($_POST['lang']) && count(Lang::getAvailableLanguages(false)) > 1) {
-                self::__render(new InstallerPage('languages'));
-            }
-
-            // Check for configuration errors and, if there are no errors, install Symphony!
-            if (isset($_POST['fields'])) {
-                $fields = $_POST['fields'];
-                $errors = self::checkConfiguration($fields);
-                if (!empty($errors)) {
-                    Symphony::Log()->error('Installer - Wrong configuration.');
-
-                    foreach ($errors as $err) {
-                        Symphony::Log()->error(sprintf('Configuration - %s', $err['msg']));
-                    }
-                } else {
-                    $disabled_extensions = self::install($fields);
-
-                    self::__render(new InstallerPage('success', array(
-                        'disabled-extensions' => $disabled_extensions
-                    )));
-                }
-            }
-
-            // Display the Installation page
-            self::__render(new InstallerPage('configuration', array(
-                'errors' => $errors,
-                'default-config' => Symphony::Configuration()->get()
+            self::__render(new InstallerPage('requirements', array(
+                'errors' => $errors
             )));
         }
 
-        /**
-         * @param InstallerPage $page
-         */
-        protected static function __render(InstallerPage $page)
-        {
-            header('Content-Type: text/html; charset=utf-8');
-            echo $page->generate();
-            exit;
+        // If language is not set and there is language packs available, show language selection pages
+        if (!isset($_POST['lang']) && count(Lang::getAvailableLanguages(false)) > 1) {
+            self::__render(new InstallerPage('languages'));
         }
 
-        /**
-         * This function checks the server can support a Symphony installation.
-         * It checks that PHP is 5.2+, MySQL, Zlib, LibXML, XSLT modules are enabled
-         * and a `install.sql` file exists.
-         * If any of these requirements fail the installation will not proceed.
-         *
-         * @return array
-         *  An associative array of errors, with `msg` and `details` keys
-         */
-        private static function __checkRequirements()
-        {
-            $errors = array();
+        // Check for configuration errors and, if there are no errors, install Symphony!
+        if (isset($_POST['fields'])) {
+            $fields = $_POST['fields'];
+            $errors = self::checkConfiguration($fields);
+            if (!empty($errors)) {
+                Symphony::Log()->error('Installer - Wrong configuration.');
 
-            // Make sure the install.sql file exists
-            if (!file_exists(INSTALL . '/includes/install.sql') || !is_readable(INSTALL . '/includes/install.sql')) {
-                $errors[] = array(
-                    'msg' => __('Missing install.sql file'),
-                    'details'  => __('It appears that %s is either missing or not readable. This is required to populate the database and must be uploaded before installation can commence. Ensure that PHP has read permissions.', array('<code>install.sql</code>'))
-                );
+                foreach ($errors as $err) {
+                    Symphony::Log()->error(sprintf('Configuration - %s', $err['msg']));
+                }
+            } else {
+                $disabled_extensions = self::install($fields);
+
+                self::__render(new InstallerPage('success', array(
+                    'disabled-extensions' => $disabled_extensions
+                )));
             }
-
-            $errors = array_merge($errors, self::$requirements->check());
-
-            return $errors;
         }
 
-        /**
-         * This function checks the current Configuration (which is the values entered
-         * by the user on the installation form) to ensure that `/symphony` and `/workspace`
-         * folders exist and are writable and that the Database credentials are correct.
-         * Once those initial checks pass, the rest of the form values are validated.
-         *
-         * @param array $fields
-         * @return array An associative array of errors if something went wrong, otherwise an empty array.
-         */
-        public static function checkConfiguration(array $fields)
-        {
-            $errors = array();
+        // Display the Installation page
+        self::__render(new InstallerPage('configuration', array(
+            'errors' => $errors,
+            'default-config' => Symphony::Configuration()->get()
+        )));
+    }
 
-            // Testing the database connection
-            try {
-                Symphony::Database()->connect(
-                    $fields['database']['host'],
-                    $fields['database']['user'],
-                    $fields['database']['password'],
-                    $fields['database']['port'],
-                    $fields['database']['db']
+    /**
+     * @param InstallerPage $page
+     */
+    protected static function __render(InstallerPage $page)
+    {
+        header('Content-Type: text/html; charset=utf-8');
+        echo $page->generate();
+        exit;
+    }
+
+    /**
+     * This function checks the server can support a Symphony installation.
+     * If any of these requirements fail the installation will not proceed.
+     *
+     * @return array
+     *  An associative array of errors, with `msg` and `details` keys
+     */
+    private static function __checkRequirements()
+    {
+        $errors = array();
+
+        // Make sure the install.sql file exists
+        if (!file_exists(INSTALL . '/includes/install.sql') || !is_readable(INSTALL . '/includes/install.sql')) {
+            $errors[] = array(
+                'msg' => __('Missing install.sql file'),
+                'details' => __(
+                    'It appears that %s is either missing or not readable. This is required to populate the database and must be uploaded before installation can commence. Ensure that PHP has read permissions.',
+                    array('<code>install.sql</code>')
+                )
+            );
+        }
+
+        $errors = array_merge($errors, self::$requirements->check());
+
+        return $errors;
+    }
+
+    /**
+     * This function checks the current Configuration (which is the values entered
+     * by the user on the installation form) to ensure that `/symphony` and `/workspace`
+     * folders exist and are writable and that the Database credentials are correct.
+     * Once those initial checks pass, the rest of the form values are validated.
+     *
+     * @param array $fields
+     * @return array An associative array of errors if something went wrong, otherwise an empty array.
+     */
+    public static function checkConfiguration(array $fields)
+    {
+        $errors = array();
+
+        // Testing the database connection
+        try {
+            Symphony::Database()->connect(
+                $fields['database']['host'],
+                $fields['database']['user'],
+                $fields['database']['password'],
+                $fields['database']['port'],
+                $fields['database']['db']
+            );
+        } catch (DatabaseException $e) {
+            // Invalid credentials
+            // @link http://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html
+            if ($e->getDatabaseErrorCode() === 1044 || $e->getDatabaseErrorCode() === 1045) {
+                $errors['database-invalid-credentials'] = array(
+                    'msg' => 'Database credentials were denied',
+                    'details' => __('Symphony was unable to access the database with these credentials.')
                 );
-            } catch (DatabaseException $e) {
-                // Invalid credentials
-                // @link http://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html
-                if ($e->getDatabaseErrorCode() === 1044 || $e->getDatabaseErrorCode() === 1045) {
-                    $errors['database-invalid-credentials'] = array(
-                        'msg' => 'Database credentials were denied',
-                        'details' => __('Symphony was unable to access the database with these credentials.')
-                    );
-                }
-                // Connection related
-                else {
-                    $errors['no-database-connection'] = array(
-                        'msg' => 'Could not establish database connection.',
-                        'details' => __('Symphony was unable to establish a valid database connection. You may need to modify host or port settings.')
-                    );
-                }
+            } // Connection related
+            else {
+                $errors['no-database-connection'] = array(
+                    'msg' => 'Could not establish database connection.',
+                    'details' => __('Symphony was unable to establish a valid database connection. You may need to modify host or port settings.')
+                );
             }
+        }
 
-            try {
-                // Check the database table prefix is legal. #1815
-                if (!preg_match('/^[0-9a-zA-Z\$_]*$/', $fields['database']['tbl_prefix'])) {
-                    $errors['database-table-prefix']  = array(
-                        'msg' => 'Invalid database table prefix: ‘' . $fields['database']['tbl_prefix'] . '’',
-                        'details' =>  __('The table prefix %s is invalid. The table prefix must only contain numbers, letters or underscore characters.', array('<code>' . $fields['database']['tbl_prefix'] . '</code>'))
+        try {
+            // Check the database table prefix is legal. #1815
+            if (!preg_match('/^[0-9a-zA-Z\$_]*$/', $fields['database']['tbl_prefix'])) {
+                $errors['database-table-prefix'] = array(
+                    'msg' => 'Invalid database table prefix: ‘' . $fields['database']['tbl_prefix'] . '’',
+                    'details' => __(
+                        'The table prefix %s is invalid. The table prefix must only contain numbers, letters or underscore characters.',
+                        array('<code>' . $fields['database']['tbl_prefix'] . '</code>')
+                    )
+                );
+            } // Check the database credentials
+            elseif (Symphony::Database()->isConnected()) {
+                // Incorrect MySQL version
+                $version = Symphony::Database()->fetchVar('version', 0, "SELECT VERSION() AS `version`;");
+                if (version_compare($version, '5.5', '<')) {
+                    $errors['database-incorrect-version'] = array(
+                        'msg' => 'MySQL Version is not correct. ' . $version . ' detected.',
+                        'details' => __(
+                            'Symphony requires %1$s or greater to work, however version %2$s was detected. This requirement must be met before installation can proceed.',
+                            array('<code>MySQL 5.5</code>', '<code>' . $version . '</code>')
+                        )
                     );
-                }
-                // Check the database credentials
-                elseif (Symphony::Database()->isConnected()) {
-                    // Incorrect MySQL version
-                    $version = Symphony::Database()->fetchVar('version', 0, "SELECT VERSION() AS `version`;");
-                    if (version_compare($version, '5.5', '<')) {
-                        $errors['database-incorrect-version']  = array(
-                            'msg' => 'MySQL Version is not correct. '. $version . ' detected.',
-                            'details' => __('Symphony requires %1$s or greater to work, however version %2$s was detected. This requirement must be met before installation can proceed.', array('<code>MySQL 5.5</code>', '<code>' . $version . '</code>'))
-                        );
-                    }
-                    else {
-                        // Existing table prefix
-                        if (Symphony::Database()->tableExists($fields['database']['tbl_prefix'] . '%')) {
-                            $errors['database-table-prefix'] = array(
-                                'msg'     => 'Database table prefix clash with ‘' . $fields['database']['db'] . '’',
-                                'details' => __('The table prefix %s is already in use. Please choose a different prefix to use with Symphony.', array(
+                } else {
+                    // Existing table prefix
+                    if (Symphony::Database()->tableExists($fields['database']['tbl_prefix'] . '%')) {
+                        $errors['database-table-prefix'] = array(
+                            'msg' => 'Database table prefix clash with ‘' . $fields['database']['db'] . '’',
+                            'details' => __(
+                                'The table prefix %s is already in use. Please choose a different prefix to use with Symphony.',
+                                array(
 
                                     '<code>' . $fields['database']['tbl_prefix'] . '</code>'
-                                ))
-                            );
-                        }
-                    }
-                }
-            } catch (DatabaseException $e) {
-                $errors['unknown-database']  = array(
-                        'msg' => 'Database ‘' . $fields['database']['db'] . '’ not found.',
-                        'details' =>  __('Symphony was unable to connect to the specified database.')
-                    );
-            }
-
-            // Website name not entered
-            if (trim($fields['general']['sitename']) === '') {
-                $errors['general-no-sitename']  = array(
-                    'msg' => 'No sitename entered.',
-                    'details' => __('You must enter a Site name. This will be shown at the top of your backend.')
-                );
-            }
-
-            // Username Not Entered
-            if (trim($fields['user']['username']) === '') {
-                $errors['user-no-username']  = array(
-                    'msg' => 'No username entered.',
-                    'details' => __('You must enter a Username. This will be your Symphony login information.')
-                );
-            }
-
-            // Password Not Entered
-            if (trim($fields['user']['password']) === '') {
-                $errors['user-no-password']  = array(
-                    'msg' => 'No password entered.',
-                    'details' => __('You must enter a Password. This will be your Symphony login information.')
-                );
-            }
-
-            // Password mismatch
-            elseif ($fields['user']['password'] !== $fields['user']['confirm-password']) {
-                $errors['user-password-mismatch']  = array(
-                    'msg' => 'Passwords did not match.',
-                    'details' => __('The password and confirmation did not match. Please retype your password.')
-                );
-            }
-
-            // No Name entered
-            if (trim($fields['user']['firstname']) === '' || trim($fields['user']['lastname']) === '') {
-                $errors['user-no-name']  = array(
-                    'msg' => 'Did not enter First and Last names.',
-                    'details' =>  __('You must enter your name.')
-                );
-            }
-
-            // Invalid Email
-            if (!preg_match('/^\w(?:\.?[\w%+-]+)*@\w(?:[\w-]*\.)+?[a-z]{2,}$/i', $fields['user']['email'])) {
-                $errors['user-invalid-email']  = array(
-                    'msg' => 'Invalid email address supplied.',
-                    'details' =>  __('This is not a valid email address. You must provide an email address since you will need it if you forget your password.')
-                );
-            }
-
-            // Admin path not entered
-            if (trim($fields['symphony']['admin-path']) === '') {
-                $errors['no-symphony-path']  = array(
-                    'msg' => 'No Symphony path entered.',
-                    'details' => __('You must enter a path for accessing Symphony, or leave the default. This will be used to access Symphony\'s backend.')
-                );
-            }
-
-            return $errors;
-        }
-
-        /**
-         * If something went wrong, the `__abort` function will write an entry to the Log
-         * file and display the failure page to the user.
-         *
-         * @todo: Resume installation after an error has been fixed.
-         * @param string $message
-         * @param integer $start
-         */
-        protected static function __abort($message, $start)
-        {
-            Symphony::Log()->error($message);
-            Symphony::Log()->error(sprintf('INSTALLATION ABORTED: Execution Time - %d sec (%s)',
-                max(1, time() - $start),
-                date('d.m.y H:i:s')
-            ));
-
-            self::__render(new InstallerPage('failure'));
-        }
-
-        /*
-         * @param array $data
-         * @return array
-         */
-        public static function install(array $data)
-        {
-            $start = microtime(true);
-            Symphony::Log()->info('INSTALLATION PROCESS STARTED (' . DateTimeObj::get('c') . ')');
-
-            // Configuration: Populating array
-            $conf = Symphony::Configuration()->get();
-
-            foreach ($conf as $group => $settings) {
-                foreach ($settings as $key => $value) {
-                    // This ensures on data the configuration cares about is populated,
-                    // anything else will be ignored and accessible in `$data`.
-                    if (isset($data[$group]) && isset($data[$group][$key])) {
-                        $conf[$group][$key] = $data[$group][$key];
+                                )
+                            )
+                        );
                     }
                 }
             }
-
-            Symphony::Configuration()->setArray($conf);
-
-            $steps = [
-                // Create database
-                Steps\CreateDatabase::class,
-                // Create manifest folder structure
-                Steps\CreateManifest::class,
-                // Write .htaccess
-                Steps\CreateHtaccess::class,
-                // Create or import the workspace
-                Steps\Workspace::class,
-                // Enable extensions
-                Steps\EnableExtensions::class,
-                // Enable language
-                Steps\EnableLanguage::class
-            ];
-
-            try {
-                foreach ($steps as $step) {
-                    $installStep = new $step(Symphony::Log()->getLog());
-                    $installStep->setOverride(false);
-
-                    if (false === $installStep->handle(Symphony::Configuration(), $data)) {
-                        throw new Exception(sprintf('Aborting installation, %s failed', $step));
-                    }
-                }
-            } catch (Exception $ex) {
-                self::__abort($ex->getMessage(), $start);
-            }
-
-            // Writing configuration file
-            Symphony::Log()->info('WRITING: Configuration File');
-            if (!Symphony::Configuration()->write(CONFIG, Symphony::Configuration()->get('write_mode', 'file'))) {
-                self::__abort(
-                    'Could not create config file ‘' . CONFIG . '’. Check permission on /manifest.',
-                    $start
-                );
-            }
-
-            // Installation completed. Woo-hoo!
-            Symphony::Log()->info(sprintf('INSTALLATION COMPLETED: Execution Time - %d sec (%s)',
-                max(1, time() - $start),
-                date('d.m.y H:i:s')
-            ));
-
-            return [];
+        } catch (DatabaseException $e) {
+            $errors['unknown-database'] = array(
+                'msg' => 'Database ‘' . $fields['database']['db'] . '’ not found.',
+                'details' => __('Symphony was unable to connect to the specified database.')
+            );
         }
 
-        protected static function __render(InstallerPage $page)
-        {
-            $output = $page->generate();
-
-            header('Content-Type: text/html; charset=utf-8');
-            echo $output;
-            exit;
+        // Website name not entered
+        if (trim($fields['general']['sitename']) === '') {
+            $errors['general-no-sitename'] = array(
+                'msg' => 'No sitename entered.',
+                'details' => __('You must enter a Site name. This will be shown at the top of your backend.')
+            );
         }
+
+        // Username Not Entered
+        if (trim($fields['user']['username']) === '') {
+            $errors['user-no-username'] = array(
+                'msg' => 'No username entered.',
+                'details' => __('You must enter a Username. This will be your Symphony login information.')
+            );
+        }
+
+        // Password Not Entered
+        if (trim($fields['user']['password']) === '') {
+            $errors['user-no-password'] = array(
+                'msg' => 'No password entered.',
+                'details' => __('You must enter a Password. This will be your Symphony login information.')
+            );
+        } // Password mismatch
+        elseif ($fields['user']['password'] !== $fields['user']['confirm-password']) {
+            $errors['user-password-mismatch'] = array(
+                'msg' => 'Passwords did not match.',
+                'details' => __('The password and confirmation did not match. Please retype your password.')
+            );
+        }
+
+        // No Name entered
+        if (trim($fields['user']['firstname']) === '' || trim($fields['user']['lastname']) === '') {
+            $errors['user-no-name'] = array(
+                'msg' => 'Did not enter First and Last names.',
+                'details' => __('You must enter your name.')
+            );
+        }
+
+        // Invalid Email
+        if (!preg_match('/^\w(?:\.?[\w%+-]+)*@\w(?:[\w-]*\.)+?[a-z]{2,}$/i', $fields['user']['email'])) {
+            $errors['user-invalid-email'] = array(
+                'msg' => 'Invalid email address supplied.',
+                'details' => __('This is not a valid email address. You must provide an email address since you will need it if you forget your password.')
+            );
+        }
+
+        // Admin path not entered
+        if (trim($fields['symphony']['admin-path']) === '') {
+            $errors['no-symphony-path'] = array(
+                'msg' => 'No Symphony path entered.',
+                'details' => __('You must enter a path for accessing Symphony, or leave the default. This will be used to access Symphony\'s backend.')
+            );
+        }
+
+        return $errors;
     }
+
+    /**
+     * @param array $data
+     * @return array
+     */
+    public static function install(array $data)
+    {
+        $start = microtime(true);
+        Symphony::Log()->info('INSTALLATION PROCESS STARTED (' . DateTimeObj::get('c') . ')');
+
+        // Configuration: Populating array
+        $conf = Symphony::Configuration()->get();
+
+        foreach ($conf as $group => $settings) {
+            foreach ($settings as $key => $value) {
+                // This ensures on data the configuration cares about is populated,
+                // anything else will be ignored and accessible in `$data`.
+                if (isset($data[$group]) && isset($data[$group][$key])) {
+                    $conf[$group][$key] = $data[$group][$key];
+                }
+            }
+        }
+
+        Symphony::Configuration()->setArray($conf);
+
+        $steps = [
+            // Create database
+            Steps\CreateDatabase::class,
+            // Create manifest folder structure
+            Steps\CreateManifest::class,
+            // Write .htaccess
+            Steps\CreateHtaccess::class,
+            // Create or import the workspace
+            Steps\Workspace::class,
+            // Enable extensions
+            Steps\EnableExtensions::class,
+            // Enable language
+            Steps\EnableLanguage::class
+        ];
+
+        try {
+            foreach ($steps as $step) {
+                $installStep = new $step(Symphony::Log()->getLog());
+                $installStep->setOverride(false);
+
+                if (false === $installStep->handle(Symphony::Configuration(), $data)) {
+                    throw new Exception(sprintf('Aborting installation, %s failed', $step));
+                }
+            }
+        } catch (Exception $ex) {
+            self::__abort($ex->getMessage(), $start);
+        }
+
+        // Writing configuration file
+        Symphony::Log()->info('WRITING: Configuration File');
+        if (!Symphony::Configuration()->write(CONFIG, Symphony::Configuration()->get('write_mode', 'file'))) {
+            self::__abort(
+                'Could not create config file ‘' . CONFIG . '’. Check permission on /manifest.',
+                $start
+            );
+        }
+
+        // Installation completed. Woo-hoo!
+        Symphony::Log()->info(sprintf(
+            'INSTALLATION COMPLETED: Execution Time - %d sec (%s)',
+            max(1, time() - $start),
+            date('d.m.y H:i:s')
+        ));
+
+        return [];
+    }
+
+    /**
+     * If something went wrong, the `__abort` function will write an entry to the Log
+     * file and display the failure page to the user.
+     *
+     * @todo: Resume installation after an error has been fixed.
+     * @param string $message
+     * @param integer $start
+     */
+    protected static function __abort($message, $start)
+    {
+        Symphony::Log()->error($message);
+        Symphony::Log()->error(sprintf(
+            'INSTALLATION ABORTED: Execution Time - %f sec (%s)',
+            microtime(true) - $start,
+            date('d.m.y H:i:s')
+        ));
+
+        self::__render(new InstallerPage('failure'));
+    }
+}

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -39,8 +39,7 @@
             }
 
             // Include the default Config for installation.
-            include(INSTALL . '/includes/config_default.php');
-            static::initialiseConfiguration($settings);
+            static::initialiseConfiguration(require_once(INSTALL . '/includes/config_default.php'));
 
             // Initialize date/time
             define_safe('__SYM_DATE_FORMAT__', self::Configuration()->get('date_format', 'region'));
@@ -402,7 +401,12 @@
 
             try {
                 foreach ($steps as $step) {
-                    (new $step(Symphony::Log()->getLog()))->handle(Symphony::Configuration(), $data);
+                    $installStep = new $step(Symphony::Log()->getLog());
+                    $installStep->setOverride(false);
+
+                    if (false === $installStep->handle(Symphony::Configuration(), $data)) {
+                        throw new Exception(sprintf('Aborting installation, %s failed', $step));
+                    }
                 }
             } catch (Exception $ex) {
                 self::__abort($ex->getMessage(), $start);

--- a/install/lib/Installer.php
+++ b/install/lib/Installer.php
@@ -1,6 +1,20 @@
 <?php
 
-    use SymphonyCms\Installer\Lib\Requirements;
+    /**
+     * @package install
+     */
+    namespace SymphonyCms\Installer\Lib;
+
+    use Administration;
+    use DatabaseException;
+    use DateTimeObj;
+    use Exception;
+    use General;
+    use GenericErrorHandler;
+    use GenericExceptionHandler;
+    use Lang;
+    use Profiler;
+    use Symphony;
     use SymphonyCms\Installer\Steps;
 
     class Installer extends Administration
@@ -153,6 +167,16 @@
                 'errors' => $errors,
                 'default-config' => Symphony::Configuration()->get()
             )));
+        }
+
+        /**
+         * @param InstallerPage $page
+         */
+        protected static function __render(InstallerPage $page)
+        {
+            header('Content-Type: text/html; charset=utf-8');
+            echo $page->generate();
+            exit;
         }
 
         /**

--- a/install/lib/InstallerPage.php
+++ b/install/lib/InstallerPage.php
@@ -1,6 +1,19 @@
 <?php
 
     /**
+     * @package install
+     */
+    namespace SymphonyCms\Installer\Lib;
+
+    use DateTimeObj;
+    use Exception;
+    use HTMLPage;
+    use Lang;
+    use Symphony;
+    use Widget;
+    use XMLElement;
+
+    /**
      * @package content
      */
 

--- a/install/lib/InstallerPage.php
+++ b/install/lib/InstallerPage.php
@@ -1,466 +1,566 @@
 <?php
 
-    /**
-     * @package install
-     */
-    namespace SymphonyCms\Installer\Lib;
+/**
+ * @package install
+ */
+namespace SymphonyCms\Installer\Lib;
 
-    use DateTimeObj;
-    use Exception;
-    use HTMLPage;
-    use Lang;
-    use Symphony;
-    use Widget;
-    use XMLElement;
+use DateTimeObj;
+use Exception;
+use HTMLPage;
+use Lang;
+use Symphony;
+use Widget;
+use XMLElement;
 
-    /**
-     * @package content
-     */
+/**
+ * @package content
+ */
+class InstallerPage extends HTMLPage
+{
+    protected $_params;
+    protected $_page_title;
+    protected $_template;
 
-    class InstallerPage extends HTMLPage
+    public function __construct($template, $params = array())
     {
-        protected $_params;
+        parent::__construct();
 
-        protected $_page_title;
+        $this->_template = $template;
+        $this->_params = $params;
 
-        protected $_template;
+        $this->_page_title = __('Install Symphony');
+    }
 
-        public function __construct($template, $params = array())
-        {
-            parent::__construct();
+    public function generate($page = null)
+    {
+        $this->Html->setDTD('<!DOCTYPE html>');
+        $this->Html->setAttribute('lang', Lang::get());
 
-            $this->_template = $template;
-            $this->_params = $params;
+        $this->addHeaderToPage('Cache-Control', 'no-cache, must-revalidate, max-age=0');
+        $this->addHeaderToPage('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT');
 
-            $this->_page_title = __('Install Symphony');
+        $this->setTitle($this->_page_title);
+        $this->addElementToHead(new XMLElement('meta', null, array('charset' => 'UTF-8')), 1);
+
+        $this->addStylesheetToHead(APPLICATION_URL . '/assets/css/installer.min.css', 'screen', 30);
+
+        return parent::generate($page);
+    }
+
+    protected function __build($version = VERSION, XMLElement $extra = null)
+    {
+        parent::__build();
+
+        $this->Form = Widget::Form(INSTALL_URL . '/index.php', 'post');
+
+        $title = new XMLElement('h1', $this->_page_title);
+        $version = new XMLElement('em', __('Version %s', array($version)));
+
+        $title->appendChild($version);
+
+        if (!is_null($extra)) {
+            $title->appendChild($extra);
         }
 
-        public function generate($page = null)
-        {
-            $this->Html->setDTD('<!DOCTYPE html>');
-            $this->Html->setAttribute('lang', Lang::get());
+        $this->Form->appendChild($title);
 
-            $this->addHeaderToPage('Cache-Control', 'no-cache, must-revalidate, max-age=0');
-            $this->addHeaderToPage('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT');
+        if (isset($this->_params['show-languages']) && $this->_params['show-languages']) {
+            $languages = new XMLElement('ul');
 
-            $this->setTitle($this->_page_title);
-            $this->addElementToHead(new XMLElement('meta', null, array('charset' => 'UTF-8')), 1);
-
-            $this->addStylesheetToHead(APPLICATION_URL . '/assets/css/installer.min.css', 'screen', 30);
-
-            return parent::generate($page);
-        }
-
-        protected function __build($version = VERSION, XMLElement $extra = null)
-        {
-            parent::__build();
-
-            $this->Form = Widget::Form(INSTALL_URL . '/index.php', 'post');
-
-            $title = new XMLElement('h1', $this->_page_title);
-            $version = new XMLElement('em', __('Version %s', array($version)));
-
-            $title->appendChild($version);
-
-            if (!is_null($extra)) {
-                $title->appendChild($extra);
-            }
-
-            $this->Form->appendChild($title);
-
-            if (isset($this->_params['show-languages']) && $this->_params['show-languages']) {
-                $languages = new XMLElement('ul');
-
-                foreach (Lang::getAvailableLanguages(false) as $code => $lang) {
-                    $languages->appendChild(new XMLElement(
-                        'li',
-                        Widget::Anchor(
-                            $lang,
-                            '?lang=' . $code
-                        ),
-                        ($_REQUEST['lang'] === $code || ($_REQUEST['lang'] === null && $code === 'en')) ? array('class' => 'selected') : array()
-                    ));
-                }
-
+            foreach (Lang::getAvailableLanguages(false) as $code => $lang) {
                 $languages->appendChild(new XMLElement(
                     'li',
                     Widget::Anchor(
-                        __('Symphony is also available in other languages'),
-                        'http://getsymphony.com/download/extensions/translations/'
+                        $lang,
+                        '?lang=' . $code
                     ),
-                    array('class' => 'more')
+                    ($_REQUEST['lang'] === $code || ($_REQUEST['lang'] === null && $code === 'en')) ? array('class' => 'selected') : array()
                 ));
-
-                $this->Form->appendChild($languages);
             }
 
-            $this->Body->appendChild($this->Form);
+            $languages->appendChild(new XMLElement(
+                'li',
+                Widget::Anchor(
+                    __('Symphony is also available in other languages'),
+                    'http://getsymphony.com/download/extensions/translations/'
+                ),
+                array('class' => 'more')
+            ));
 
-            $function = 'view' . str_replace('-', '', ucfirst($this->_template));
-            $this->$function();
+            $this->Form->appendChild($languages);
         }
 
-        protected function viewMissinglog()
-        {
-            $h2 = new XMLElement('h2', __('Missing log file'));
+        $this->Body->appendChild($this->Form);
 
-            // What folder wasn't writable? The docroot or the logs folder?
-            // RE: #1706
-            if (is_writeable(DOCROOT) === false) {
-                $folder = DOCROOT;
-            } elseif (is_writeable(MANIFEST) === false) {
-                $folder = MANIFEST;
-            } elseif (is_writeable(INSTALL_LOGS) === false) {
-                $folder = INSTALL_LOGS;
-            }
+        $function = 'view' . str_replace('-', '', ucfirst($this->_template));
+        $this->$function();
+    }
 
-            $p = new XMLElement('p', __('Symphony tried to create a log file and failed. Make sure the %s folder is writable.', array('<code>' . $folder . '</code>')));
+    protected function viewMissinglog()
+    {
+        $h2 = new XMLElement('h2', __('Missing log file'));
 
-            $this->Form->appendChild($h2);
-            $this->Form->appendChild($p);
+        // What folder wasn't writable? The docroot or the logs folder?
+        // RE: #1706
+        if (is_writeable(DOCROOT) === false) {
+            $folder = DOCROOT;
+        } elseif (is_writeable(MANIFEST) === false) {
+            $folder = MANIFEST;
+        } elseif (is_writeable(INSTALL_LOGS) === false) {
+            $folder = INSTALL_LOGS;
         }
 
-        protected function viewRequirements()
-        {
-            $h2 = new XMLElement('h2', __('System Requirements'));
+        $p = new XMLElement(
+            'p',
+            __(
+                'Symphony tried to create a log file and failed. Make sure the %s folder is writable.',
+                array('<code>' . $folder . '</code>')
+            )
+        );
 
-            $this->Form->appendChild($h2);
+        $this->Form->appendChild($h2);
+        $this->Form->appendChild($p);
+    }
 
-            if (!empty($this->_params['errors'])) {
-                $div = new XMLElement('div');
-                $this->__appendError(array_keys($this->_params['errors']), $div, __('Symphony needs the following requirements to be met before things can be taken to the “next level”.'));
+    protected function viewRequirements()
+    {
+        $h2 = new XMLElement('h2', __('System Requirements'));
 
-                $this->Form->appendChild($div);
-            }
-        }
+        $this->Form->appendChild($h2);
 
-        protected function viewLanguages()
-        {
-            $h2 = new XMLElement('h2', __('Language selection'));
-            $p = new XMLElement('p', __('This installation can speak in different languages. Which one are you fluent in?'));
-
-            $this->Form->appendChild($h2);
-            $this->Form->appendChild($p);
-
-            $languages = array();
-
-            foreach (Lang::getAvailableLanguages(false) as $code => $lang) {
-                $languages[] = array($code, ($code === 'en'), $lang);
-            }
-
-            if (count($languages) > 1) {
-                $languages[0][1] = false;
-                $languages[1][1] = true;
-            }
-
-            $this->Form->appendChild(Widget::Select('lang', $languages));
-
-            $Submit = new XMLElement('div', null, array('class' => 'submit'));
-            $Submit->appendChild(Widget::Input('action[proceed]', __('Proceed with installation'), 'submit'));
-
-            $this->Form->appendChild($Submit);
-        }
-
-        protected function viewFailure()
-        {
-            $h2 = new XMLElement('h2', __('Installation Failure'));
-            $p = new XMLElement('p', __('An error occurred during installation.'));
-
-            // Attempt to get log information from the log file
-            try {
-                $log = file_get_contents(INSTALL_LOGS . '/install');
-            } catch (Exception $ex) {
-                $log = (string)$ex;
-            }
-
-            $code = new XMLElement('code', $log);
-
-            $this->Form->appendChild($h2);
-            $this->Form->appendChild($p);
-            $this->Form->appendChild(
-                new XMLElement('pre', $code)
-            );
-        }
-
-        protected function viewSuccess()
-        {
-            $symphonyUrl = URL . '/' . Symphony::Configuration()->get('admin-path', 'symphony');
-            $this->Form->setAttribute('action', $symphonyUrl);
-
+        if (!empty($this->_params['errors'])) {
             $div = new XMLElement('div');
-            $div->appendChild(
-                new XMLElement('h2', __('The floor is yours'))
+            $this->__appendError(
+                array_keys($this->_params['errors']),
+                $div,
+                __('Symphony needs the following requirements to be met before things can be taken to the “next level”.')
             );
-            $div->appendChild(
-                new XMLElement('p', __('Thanks for taking the quick, yet epic installation journey with us. It’s now your turn to shine!'))
-            );
+
             $this->Form->appendChild($div);
+        }
+    }
 
-            $ul = new XMLElement('ul');
-            foreach ($this->_params['disabled-extensions'] as $handle) {
-                $ul->appendChild(
-                    new XMLElement('li', '<code>' . $handle . '</code>')
-                );
+    private function __appendError(array $codes, XMLElement &$element, $message = null)
+    {
+        if (is_null($message)) {
+            $message = __('The following errors have been reported:');
+        }
+
+        foreach ($codes as $i => $c) {
+            if (!isset($this->_params['errors'][$c])) {
+                unset($codes[$i]);
             }
+        }
 
-            if ($ul->getNumberOfChildren() !== 0) {
-                $this->Form->appendChild(
-                    new XMLElement('p',
-                        __('Looks like the following extensions couldn’t be enabled and must be manually installed. It’s a minor setback in our otherwise prosperous future together.')
-                    )
-                );
-                $this->Form->appendChild($ul);
+        if (!empty($codes)) {
+            if (count($codes) > 1) {
+                $ul = new XMLElement('ul');
+
+                foreach ($codes as $c) {
+                    if (isset($this->_params['errors'][$c])) {
+                        $ul->appendChild(new XMLElement('li', $this->_params['errors'][$c]['details']));
+                    }
+                }
+
+                $element = Widget::Error($element, $message);
+                $element->appendChild($ul);
+            } else {
+                $code = array_pop($codes);
+
+                if (isset($this->_params['errors'][$code])) {
+                    $element = Widget::Error($element, $this->_params['errors'][$code]['details']);
+                }
             }
+        }
+    }
 
+    protected function viewLanguages()
+    {
+        $h2 = new XMLElement('h2', __('Language selection'));
+        $p = new XMLElement(
+            'p',
+            __('This installation can speak in different languages. Which one are you fluent in?')
+        );
+
+        $this->Form->appendChild($h2);
+        $this->Form->appendChild($p);
+
+        $languages = array();
+
+        foreach (Lang::getAvailableLanguages(false) as $code => $lang) {
+            $languages[] = array($code, ($code === 'en'), $lang);
+        }
+
+        if (count($languages) > 1) {
+            $languages[0][1] = false;
+            $languages[1][1] = true;
+        }
+
+        $this->Form->appendChild(Widget::Select('lang', $languages));
+
+        $Submit = new XMLElement('div', null, array('class' => 'submit'));
+        $Submit->appendChild(Widget::Input('action[proceed]', __('Proceed with installation'), 'submit'));
+
+        $this->Form->appendChild($Submit);
+    }
+
+    protected function viewFailure()
+    {
+        $h2 = new XMLElement('h2', __('Installation Failure'));
+        $p = new XMLElement('p', __('An error occurred during installation.'));
+
+        // Attempt to get log information from the log file
+        try {
+            $log = file_get_contents(INSTALL_LOGS . '/install');
+        } catch (Exception $ex) {
+            $log = (string)$ex;
+        }
+
+        $code = new XMLElement('code', $log);
+
+        $this->Form->appendChild($h2);
+        $this->Form->appendChild($p);
+        $this->Form->appendChild(
+            new XMLElement('pre', $code)
+        );
+    }
+
+    protected function viewSuccess()
+    {
+        $symphonyUrl = URL . '/' . Symphony::Configuration()->get('admin-path', 'symphony');
+        $this->Form->setAttribute('action', $symphonyUrl);
+
+        $div = new XMLElement('div');
+        $div->appendChild(
+            new XMLElement('h2', __('The floor is yours'))
+        );
+        $div->appendChild(
+            new XMLElement(
+                'p',
+                __('Thanks for taking the quick, yet epic installation journey with us. It’s now your turn to shine!')
+            )
+        );
+        $this->Form->appendChild($div);
+
+        $ul = new XMLElement('ul');
+        foreach ($this->_params['disabled-extensions'] as $handle) {
+            $ul->appendChild(
+                new XMLElement('li', '<code>' . $handle . '</code>')
+            );
+        }
+
+        if ($ul->getNumberOfChildren() !== 0) {
             $this->Form->appendChild(
-                new XMLElement('p',
-                    __('I think you and I will achieve great things together. Just one last thing: how about we remove the %s folder and secure the safety of our relationship?', array('<code>' . basename(INSTALL) . '</code>'))
+                new XMLElement(
+                    'p',
+                    __('Looks like the following extensions couldn’t be enabled and must be manually installed. It’s a minor setback in our otherwise prosperous future together.')
                 )
             );
-
-            $submit = new XMLElement('div', null, array('class' => 'submit'));
-            $submit->appendChild(Widget::Input('submit', __('Okay, now take me to the login page'), 'submit'));
-
-            $this->Form->appendChild($submit);
+            $this->Form->appendChild($ul);
         }
 
-        protected function viewConfiguration()
-        {
-            /* -----------------------------------------------
-             * Populating fields array
-             * -----------------------------------------------
-             */
+        $this->Form->appendChild(
+            new XMLElement(
+                'p',
+                __(
+                    'I think you and I will achieve great things together. Just one last thing: how about we remove the %s folder and secure the safety of our relationship?',
+                    array('<code>' . basename(INSTALL) . '</code>')
+                )
+            )
+        );
 
-            $fields = isset($_POST['fields']) ? $_POST['fields'] : $this->_params['default-config'];
+        $submit = new XMLElement('div', null, array('class' => 'submit'));
+        $submit->appendChild(Widget::Input('submit', __('Okay, now take me to the login page'), 'submit'));
 
-            /* -----------------------------------------------
-             * Welcome
-             * -----------------------------------------------
-             */
+        $this->Form->appendChild($submit);
+    }
 
-            $div = new XMLElement('div');
-            $div->appendChild(
-                new XMLElement('h2', __('Find something sturdy to hold on to because things are about to get awesome.'))
+    protected function viewConfiguration()
+    {
+        /* -----------------------------------------------
+         * Populating fields array
+         * -----------------------------------------------
+         */
+
+        $fields = isset($_POST['fields']) ? $_POST['fields'] : $this->_params['default-config'];
+
+        /* -----------------------------------------------
+         * Welcome
+         * -----------------------------------------------
+         */
+
+        $div = new XMLElement('div');
+        $div->appendChild(
+            new XMLElement('h2', __('Find something sturdy to hold on to because things are about to get awesome.'))
+        );
+        $div->appendChild(
+            new XMLElement(
+                'p',
+                __('Think of this as a pre-game warm up. You know you’re going to kick-ass, so you’re savouring every moment before the show. Welcome to the Symphony install page.')
+            )
+        );
+
+        $this->Form->appendChild($div);
+
+        if (!empty($this->_params['errors'])) {
+            $this->Form->appendChild(
+                Widget::Error(
+                    new XMLElement('p'),
+                    __('Oops, a minor hurdle on your path to glory! There appears to be something wrong with the details entered below.')
+                )
             );
-            $div->appendChild(
-                new XMLElement('p', __('Think of this as a pre-game warm up. You know you’re going to kick-ass, so you’re savouring every moment before the show. Welcome to the Symphony install page.'))
-            );
-
-            $this->Form->appendChild($div);
-
-            if (!empty($this->_params['errors'])) {
-                $this->Form->appendChild(
-                    Widget::Error(new XMLElement('p'), __('Oops, a minor hurdle on your path to glory! There appears to be something wrong with the details entered below.'))
-                );
-            }
+        }
 
         /* -----------------------------------------------
          * Environment settings
          * -----------------------------------------------
          */
 
-            $fieldset = new XMLElement('fieldset');
-            $div = new XMLElement('div');
-            $this->__appendError(array('no-write-permission-root', 'no-write-permission-workspace'), $div);
-            if ($div->getNumberOfChildren() > 0) {
-                $fieldset->appendChild($div);
-                $this->Form->appendChild($fieldset);
-            }
+        $fieldset = new XMLElement('fieldset');
+        $div = new XMLElement('div');
+        $this->__appendError(array('no-write-permission-root', 'no-write-permission-workspace'), $div);
+        if ($div->getNumberOfChildren() > 0) {
+            $fieldset->appendChild($div);
+            $this->Form->appendChild($fieldset);
+        }
 
         /* -----------------------------------------------
          * Website & Locale settings
          * -----------------------------------------------
          */
 
-            $Environment = new XMLElement('fieldset');
-            $Environment->appendChild(new XMLElement('legend', __('Website Preferences')));
+        $Environment = new XMLElement('fieldset');
+        $Environment->appendChild(new XMLElement('legend', __('Website Preferences')));
 
-            $label = Widget::Label(__('Name'), Widget::Input('fields[general][sitename]', $fields['general']['sitename']));
+        $label = Widget::Label(
+            __('Name'),
+            Widget::Input('fields[general][sitename]', $fields['general']['sitename'])
+        );
 
-            $this->__appendError(array('general-no-sitename'), $label);
-            $Environment->appendChild($label);
+        $this->__appendError(array('general-no-sitename'), $label);
+        $Environment->appendChild($label);
 
-            $label = Widget::Label(__('Admin Path'), Widget::Input('fields[symphony][admin-path]', $fields['symphony']['admin-path']));
+        $label = Widget::Label(
+            __('Admin Path'),
+            Widget::Input('fields[symphony][admin-path]', $fields['symphony']['admin-path'])
+        );
 
-            $this->__appendError(array('no-symphony-path'), $label);
-            $Environment->appendChild($label);
+        $this->__appendError(array('no-symphony-path'), $label);
+        $Environment->appendChild($label);
 
-            $Fieldset = new XMLElement('fieldset', null, array('class' => 'frame'));
-            $Fieldset->appendChild(new XMLElement('legend', __('Date and Time')));
-            $Fieldset->appendChild(new XMLElement('p', __('Customise how Date and Time values are displayed throughout the Administration interface.')));
+        $Fieldset = new XMLElement('fieldset', null, array('class' => 'frame'));
+        $Fieldset->appendChild(new XMLElement('legend', __('Date and Time')));
+        $Fieldset->appendChild(new XMLElement(
+            'p',
+            __('Customise how Date and Time values are displayed throughout the Administration interface.')
+        ));
 
-            // Timezones
-            $options = DateTimeObj::getTimezonesSelectOptions((
-                isset($fields['region']['timezone']) && !empty($fields['region']['timezone'])
-                    ? $fields['region']['timezone']
-                    : date_default_timezone_get()
-            ));
-            $Fieldset->appendChild(Widget::Label(__('Region'), Widget::Select('fields[region][timezone]', $options)));
+        // Timezones
+        $options = DateTimeObj::getTimezonesSelectOptions((
+        isset($fields['region']['timezone']) && !empty($fields['region']['timezone'])
+            ? $fields['region']['timezone']
+            : date_default_timezone_get()
+        ));
+        $Fieldset->appendChild(Widget::Label(__('Region'), Widget::Select('fields[region][timezone]', $options)));
 
-            // Date formats
-            $options = DateTimeObj::getDateFormatsSelectOptions($fields['region']['date_format']);
-            $Fieldset->appendChild(Widget::Label(__('Date Format'), Widget::Select('fields[region][date_format]', $options)));
+        // Date formats
+        $options = DateTimeObj::getDateFormatsSelectOptions($fields['region']['date_format']);
+        $Fieldset->appendChild(Widget::Label(
+            __('Date Format'),
+            Widget::Select('fields[region][date_format]', $options)
+        ));
 
-            // Time formats
-            $options = DateTimeObj::getTimeFormatsSelectOptions($fields['region']['time_format']);
-            $Fieldset->appendChild(Widget::Label(__('Time Format'), Widget::Select('fields[region][time_format]', $options)));
+        // Time formats
+        $options = DateTimeObj::getTimeFormatsSelectOptions($fields['region']['time_format']);
+        $Fieldset->appendChild(Widget::Label(
+            __('Time Format'),
+            Widget::Select('fields[region][time_format]', $options)
+        ));
 
-            $Environment->appendChild($Fieldset);
-            $this->Form->appendChild($Environment);
+        $Environment->appendChild($Fieldset);
+        $this->Form->appendChild($Environment);
 
         /* -----------------------------------------------
          * Database settings
          * -----------------------------------------------
          */
 
-            $Database = new XMLElement('fieldset');
-            $Database->appendChild(new XMLElement('legend', __('Database Connection')));
-            $Database->appendChild(new XMLElement('p', __('Please provide Symphony with access to a database.')));
+        $Database = new XMLElement('fieldset');
+        $Database->appendChild(new XMLElement('legend', __('Database Connection')));
+        $Database->appendChild(new XMLElement('p', __('Please provide Symphony with access to a database.')));
 
-            // Database name
-            $label = Widget::Label(__('Database'), Widget::Input('fields[database][db]', $fields['database']['db']));
+        // Database name
+        $label = Widget::Label(__('Database'), Widget::Input('fields[database][db]', $fields['database']['db']));
 
-            $this->__appendError(array('database-incorrect-version', 'unknown-database'), $label);
-            $Database->appendChild($label);
+        $this->__appendError(array('database-incorrect-version', 'unknown-database'), $label);
+        $Database->appendChild($label);
 
-            // Database credentials
-            $Div = new XMLElement('div', null, array('class' => 'two columns'));
-            $Div->appendChild(Widget::Label(__('Username'), Widget::Input('fields[database][user]', $fields['database']['user']), 'column'));
-            $Div->appendChild(Widget::Label(__('Password'), Widget::Input('fields[database][password]', $fields['database']['password'], 'password'), 'column'));
+        // Database credentials
+        $Div = new XMLElement('div', null, array('class' => 'two columns'));
+        $Div->appendChild(Widget::Label(
+            __('Username'),
+            Widget::Input('fields[database][user]', $fields['database']['user']),
+            'column'
+        ));
+        $Div->appendChild(Widget::Label(
+            __('Password'),
+            Widget::Input('fields[database][password]', $fields['database']['password'], 'password'),
+            'column'
+        ));
 
-            $this->__appendError(array('database-invalid-credentials'), $Div);
-            $Database->appendChild($Div);
+        $this->__appendError(array('database-invalid-credentials'), $Div);
+        $Database->appendChild($Div);
 
-            // Advanced configuration
-            $Fieldset = new XMLElement('fieldset', null, array('class' => 'frame'));
-            $Fieldset->appendChild(new XMLElement('legend', __('Advanced Configuration')));
-            $Fieldset->appendChild(new XMLElement('p', __('Leave these fields unless you are sure they need to be changed.')));
+        // Advanced configuration
+        $Fieldset = new XMLElement('fieldset', null, array('class' => 'frame'));
+        $Fieldset->appendChild(new XMLElement('legend', __('Advanced Configuration')));
+        $Fieldset->appendChild(new XMLElement(
+            'p',
+            __('Leave these fields unless you are sure they need to be changed.')
+        ));
 
-            // Advanced configuration: Host, Port
-            $Div = new XMLElement('div', null, array('class' => 'two columns'));
-            $Div->appendChild(Widget::Label(__('Host'), Widget::Input('fields[database][host]', $fields['database']['host']), 'column'));
-            $Div->appendChild(Widget::Label(__('Port'), Widget::Input('fields[database][port]', $fields['database']['port']), 'column'));
+        // Advanced configuration: Host, Port
+        $Div = new XMLElement('div', null, array('class' => 'two columns'));
+        $Div->appendChild(Widget::Label(
+            __('Host'),
+            Widget::Input('fields[database][host]', $fields['database']['host']),
+            'column'
+        ));
+        $Div->appendChild(Widget::Label(
+            __('Port'),
+            Widget::Input('fields[database][port]', $fields['database']['port']),
+            'column'
+        ));
 
-            $this->__appendError(array('no-database-connection'), $Div);
-            $Fieldset->appendChild($Div);
+        $this->__appendError(array('no-database-connection'), $Div);
+        $Fieldset->appendChild($Div);
 
-            // Advanced configuration: Table Prefix
-            $label = Widget::Label(__('Table Prefix'), Widget::Input('fields[database][tbl_prefix]', $fields['database']['tbl_prefix']));
+        // Advanced configuration: Table Prefix
+        $label = Widget::Label(
+            __('Table Prefix'),
+            Widget::Input('fields[database][tbl_prefix]', $fields['database']['tbl_prefix'])
+        );
 
-            $this->__appendError(array('database-table-prefix'), $label);
-            $Fieldset->appendChild($label);
+        $this->__appendError(array('database-table-prefix'), $label);
+        $Fieldset->appendChild($label);
 
-            $Database->appendChild($Fieldset);
-            $this->Form->appendChild($Database);
+        $Database->appendChild($Fieldset);
+        $this->Form->appendChild($Database);
 
         /* -----------------------------------------------
          * Permission settings
          * -----------------------------------------------
          */
 
-            $Permissions = new XMLElement('fieldset');
-            $Permissions->appendChild(new XMLElement('legend', __('Permission Settings')));
-            $Permissions->appendChild(new XMLElement('p', __('Set the permissions Symphony uses when saving files/directories.')));
+        $Permissions = new XMLElement('fieldset');
+        $Permissions->appendChild(new XMLElement('legend', __('Permission Settings')));
+        $Permissions->appendChild(new XMLElement(
+            'p',
+            __('Set the permissions Symphony uses when saving files/directories.')
+        ));
 
-            $Div = new XMLElement('div', null, array('class' => 'two columns'));
-            $Div->appendChild(Widget::Label(__('Files'), Widget::Input('fields[file][write_mode]', $fields['file']['write_mode']), 'column'));
-            $Div->appendChild(Widget::Label(__('Directories'), Widget::Input('fields[directory][write_mode]', $fields['directory']['write_mode']), 'column'));
+        $Div = new XMLElement('div', null, array('class' => 'two columns'));
+        $Div->appendChild(Widget::Label(
+            __('Files'),
+            Widget::Input('fields[file][write_mode]', $fields['file']['write_mode']),
+            'column'
+        ));
+        $Div->appendChild(Widget::Label(
+            __('Directories'),
+            Widget::Input('fields[directory][write_mode]', $fields['directory']['write_mode']),
+            'column'
+        ));
 
-            $Permissions->appendChild($Div);
-            $this->Form->appendChild($Permissions);
+        $Permissions->appendChild($Div);
+        $this->Form->appendChild($Permissions);
 
         /* -----------------------------------------------
          * User settings
          * -----------------------------------------------
          */
 
-            $User = new XMLElement('fieldset');
-            $User->appendChild(new XMLElement('legend', __('User Information')));
-            $User->appendChild(new XMLElement('p', __('Once installation is complete, you will be able to log in to the Symphony admin area with these user details.')));
+        $User = new XMLElement('fieldset');
+        $User->appendChild(new XMLElement('legend', __('User Information')));
+        $User->appendChild(new XMLElement(
+            'p',
+            __('Once installation is complete, you will be able to log in to the Symphony admin area with these user details.')
+        ));
 
-            // Username
-            $label = Widget::Label(__('Username'), Widget::Input('fields[user][username]', $fields['user']['username']));
+        // Username
+        $label = Widget::Label(
+            __('Username'),
+            Widget::Input('fields[user][username]', $fields['user']['username'])
+        );
 
-            $this->__appendError(array('user-no-username'), $label);
-            $User->appendChild($label);
+        $this->__appendError(array('user-no-username'), $label);
+        $User->appendChild($label);
 
-            // Password
-            $Div = new XMLElement('div', null, array('class' => 'two columns'));
-            $Div->appendChild(Widget::Label(__('Password'), Widget::Input('fields[user][password]', $fields['user']['password'], 'password'), 'column'));
-            $Div->appendChild(Widget::Label(__('Confirm Password'), Widget::Input('fields[user][confirm-password]', $fields['user']['confirm-password'], 'password'), 'column'));
+        // Password
+        $Div = new XMLElement('div', null, array('class' => 'two columns'));
+        $Div->appendChild(Widget::Label(
+            __('Password'),
+            Widget::Input('fields[user][password]', $fields['user']['password'], 'password'),
+            'column'
+        ));
+        $Div->appendChild(Widget::Label(
+            __('Confirm Password'),
+            Widget::Input('fields[user][confirm-password]', $fields['user']['confirm-password'], 'password'),
+            'column'
+        ));
 
-            $this->__appendError(array('user-no-password', 'user-password-mismatch'), $Div);
-            $User->appendChild($Div);
+        $this->__appendError(array('user-no-password', 'user-password-mismatch'), $Div);
+        $User->appendChild($Div);
 
-            // Personal information
-            $Fieldset = new XMLElement('fieldset', null, array('class' => 'frame'));
-            $Fieldset->appendChild(new XMLElement('legend', __('Personal Information')));
-            $Fieldset->appendChild(new XMLElement('p', __('Please add the following personal details for this user.')));
+        // Personal information
+        $Fieldset = new XMLElement('fieldset', null, array('class' => 'frame'));
+        $Fieldset->appendChild(new XMLElement('legend', __('Personal Information')));
+        $Fieldset->appendChild(new XMLElement('p', __('Please add the following personal details for this user.')));
 
-            // Personal information: First Name, Last Name
-            $Div = new XMLElement('div', null, array('class' => 'two columns'));
-            $Div->appendChild(Widget::Label(__('First Name'), Widget::Input('fields[user][firstname]', $fields['user']['firstname']), 'column'));
-            $Div->appendChild(Widget::Label(__('Last Name'), Widget::Input('fields[user][lastname]', $fields['user']['lastname']), 'column'));
+        // Personal information: First Name, Last Name
+        $Div = new XMLElement('div', null, array('class' => 'two columns'));
+        $Div->appendChild(Widget::Label(
+            __('First Name'),
+            Widget::Input('fields[user][firstname]', $fields['user']['firstname']),
+            'column'
+        ));
+        $Div->appendChild(Widget::Label(
+            __('Last Name'),
+            Widget::Input('fields[user][lastname]', $fields['user']['lastname']),
+            'column'
+        ));
 
-            $this->__appendError(array('user-no-name'), $Div);
-            $Fieldset->appendChild($Div);
+        $this->__appendError(array('user-no-name'), $Div);
+        $Fieldset->appendChild($Div);
 
-            // Personal information: Email Address
-            $label = Widget::Label(__('Email Address'), Widget::Input('fields[user][email]', $fields['user']['email']));
+        // Personal information: Email Address
+        $label = Widget::Label(__('Email Address'), Widget::Input('fields[user][email]', $fields['user']['email']));
 
-            $this->__appendError(array('user-invalid-email'), $label);
-            $Fieldset->appendChild($label);
+        $this->__appendError(array('user-invalid-email'), $label);
+        $Fieldset->appendChild($label);
 
-            $User->appendChild($Fieldset);
-            $this->Form->appendChild($User);
+        $User->appendChild($Fieldset);
+        $this->Form->appendChild($User);
 
         /* -----------------------------------------------
          * Submit area
          * -----------------------------------------------
          */
 
-            $this->Form->appendChild(new XMLElement('h2', __('Install Symphony')));
-            $this->Form->appendChild(new XMLElement('p', __('The installation process goes by really quickly. Make sure to take a deep breath before you press that sweet button.', array('<code>' . basename(INSTALL_URL) . '</code>'))));
+        $this->Form->appendChild(new XMLElement('h2', __('Install Symphony')));
+        $this->Form->appendChild(new XMLElement(
+            'p',
+            __(
+                'The installation process goes by really quickly. Make sure to take a deep breath before you press that sweet button.',
+                array('<code>' . basename(INSTALL_URL) . '</code>')
+            )
+        ));
 
-            $Submit = new XMLElement('div', null, array('class' => 'submit'));
-            $Submit->appendChild(Widget::Input('lang', Lang::get(), 'hidden'));
+        $Submit = new XMLElement('div', null, array('class' => 'submit'));
+        $Submit->appendChild(Widget::Input('lang', Lang::get(), 'hidden'));
 
-            $Submit->appendChild(Widget::Input('action[install]', __('Install Symphony'), 'submit'));
+        $Submit->appendChild(Widget::Input('action[install]', __('Install Symphony'), 'submit'));
 
-            $this->Form->appendChild($Submit);
-        }
-
-        private function __appendError(array $codes, XMLElement &$element, $message = null)
-        {
-            if (is_null($message)) {
-                $message =  __('The following errors have been reported:');
-            }
-
-            foreach ($codes as $i => $c) {
-                if (!isset($this->_params['errors'][$c])) {
-                    unset($codes[$i]);
-                }
-            }
-
-            if (!empty($codes)) {
-                if (count($codes) > 1) {
-                    $ul = new XMLElement('ul');
-
-                    foreach ($codes as $c) {
-                        if (isset($this->_params['errors'][$c])) {
-                            $ul->appendChild(new XMLElement('li', $this->_params['errors'][$c]['details']));
-                        }
-                    }
-
-                    $element = Widget::Error($element, $message);
-                    $element->appendChild($ul);
-                } else {
-                    $code = array_pop($codes);
-
-                    if (isset($this->_params['errors'][$code])) {
-                        $element = Widget::Error($element, $this->_params['errors'][$code]['details']);
-                    }
-                }
-            }
-        }
+        $this->Form->appendChild($Submit);
     }
+}

--- a/install/lib/Migration.php
+++ b/install/lib/Migration.php
@@ -3,6 +3,11 @@
     /**
      * @package install
      */
+    namespace SymphonyCms\Installer\Lib;
+
+    use DatabaseException;
+    use Exception;
+    use Symphony;
 
     /**
      * The Migration class is extended by updates files that contain the necessary
@@ -35,9 +40,7 @@
             static::$existing_version = $existing_version;
 
             try {
-                $canProceed = static::$function();
-
-                return ($canProceed === false) ? false : true;
+                return static::$function();
             } catch (DatabaseException $e) {
                 Symphony::Log()->error('Could not complete upgrading. MySQL returned: ' . $e->getDatabaseErrorCode() . ': ' . $e->getMessage());
 
@@ -87,9 +90,9 @@
 
             if (Symphony::Configuration()->write() === false) {
                 throw new Exception('Failed to write configuration file, please check the file permissions.');
-            } else {
-                return true;
             }
+
+            return true;
         }
 
         /**

--- a/install/lib/Requirements.php
+++ b/install/lib/Requirements.php
@@ -1,0 +1,87 @@
+<?php
+
+    namespace SymphonyCms\Installer\Lib;
+
+    class Requirements
+    {
+        /**
+         * @return array
+         */
+        public function check()
+        {
+            $errors = array();
+
+            // Check for PHP 5.2+
+            if (version_compare(phpversion(), '5.3', '<=')) {
+                $errors[] = array(
+                    'msg' => __('PHP Version is not correct'),
+                    'details' => __('Symphony requires %1$s or greater to work, however version %2$s was detected.',
+                        array(
+                            '<code><abbr title="PHP: Hypertext Pre-processor">PHP</abbr> 5.3</code>',
+                            '<code>' . phpversion() . '</code>'
+                        ))
+                );
+            }
+
+            // Is MySQL available?
+            if (!function_exists('mysqli_connect')) {
+                $errors[] = array(
+                    'msg' => __('MySQLi extension not present'),
+                    'details' => __('Symphony requires PHP to be configured with MySQLi to work.')
+                );
+            }
+
+            // Is ZLib available?
+            if (!extension_loaded('zlib')) {
+                $errors[] = array(
+                    'msg' => __('ZLib extension not present'),
+                    'details' => __('Symphony uses the ZLib compression library for log rotation.')
+                );
+            }
+
+            // Is libxml available?
+            if (!extension_loaded('xml') && !extension_loaded('libxml')) {
+                $errors[] = array(
+                    'msg' => __('XML extension not present'),
+                    'details' => __('Symphony needs the XML extension to pass data to the site frontend.')
+                );
+            }
+
+            // Is libxslt available?
+            if (!extension_loaded('xsl') && !extension_loaded('xslt') && !function_exists('domxml_xslt_stylesheet')) {
+                $errors[] = array(
+                    'msg' => __('XSLT extension not present'),
+                    'details' => __('Symphony needs an XSLT processor such as %s or Sablotron to build pages.',
+                        array('Lib<abbr title="eXtensible Stylesheet Language Transformation">XSLT</abbr>'))
+                );
+            }
+
+            // Is json_encode available?
+            if (!function_exists('json_decode')) {
+                $errors[] = array(
+                    'msg' => __('JSON functionality is not present'),
+                    'details' => __('Symphony uses JSON functionality throughout the backend for translations and the interface.')
+                );
+            }
+
+            // Cannot write to root folder.
+            if (!is_writable(DOCROOT)) {
+                $errors['no-write-permission-root'] = array(
+                    'msg' => 'Root folder not writable: ' . DOCROOT,
+                    'details' => __('Symphony does not have write permission to the root directory. Please modify permission settings on %s. This can be reverted once installation is complete.',
+                        array('<code>' . DOCROOT . '</code>'))
+                );
+            }
+
+            // Cannot write to workspace
+            if (is_dir(DOCROOT . '/workspace') && !is_writable(DOCROOT . '/workspace')) {
+                $errors['no-write-permission-workspace'] = array(
+                    'msg' => 'Workspace folder not writable: ' . DOCROOT . '/workspace',
+                    'details' => __('Symphony does not have write permission to the existing %1$s directory. Please modify permission settings on this directory and its contents to allow this, such as with a recursive %2$s command.',
+                        array('<code>/workspace</code>', '<code>chmod -R</code>'))
+                );
+            }
+
+            return $errors;
+        }
+    }

--- a/install/lib/Requirements.php
+++ b/install/lib/Requirements.php
@@ -14,8 +14,8 @@
         {
             $errors = array();
 
-            // Check for PHP 5.2+
-            if (version_compare(phpversion(), '5.3', '<=')) {
+            // Check for PHP 5.4+
+            if (version_compare(phpversion(), '5.4', '<=')) {
                 $errors[] = array(
                     'msg' => __('PHP Version is not correct'),
                     'details' => __('Symphony requires %1$s or greater to work, however version %2$s was detected.',
@@ -27,7 +27,7 @@
             }
 
             // Is PDO available?
-            if (!function_exists('pdo')) {
+            if (!extension_loaded('pdo')) {
                 $errors[] = array(
                     'msg' => __('PDO extension not present'),
                     'details' => __('Symphony requires PHP to be configured with PDO to work.')
@@ -35,7 +35,7 @@
             }
 
             // Is CURL available?
-            if (!function_exists('curl')) {
+            if (!extension_loaded('curl')) {
                 $errors[] = array(
                     'msg' => __('CURL extension not present'),
                     'details' => __('Symphony requires PHP to be configured with CURL for HTTP communication.')

--- a/install/lib/Requirements.php
+++ b/install/lib/Requirements.php
@@ -15,12 +15,12 @@
             $errors = array();
 
             // Check for PHP 5.4+
-            if (version_compare(phpversion(), '5.4', '<=')) {
+            if (version_compare(phpversion(), '5.5.9', '<=')) {
                 $errors[] = array(
                     'msg' => __('PHP Version is not correct'),
                     'details' => __('Symphony requires %1$s or greater to work, however version %2$s was detected.',
                         array(
-                            '<code><abbr title="PHP: Hypertext Pre-processor">PHP</abbr> 5.3</code>',
+                            '<code><abbr title="PHP: Hypertext Pre-processor">PHP</abbr> 5.5.9</code>',
                             '<code>' . phpversion() . '</code>'
                         ))
                 );

--- a/install/lib/Requirements.php
+++ b/install/lib/Requirements.php
@@ -1,5 +1,8 @@
 <?php
 
+    /**
+     * @package install
+     */
     namespace SymphonyCms\Installer\Lib;
 
     class Requirements

--- a/install/lib/Requirements.php
+++ b/install/lib/Requirements.php
@@ -1,90 +1,98 @@
 <?php
 
+/**
+ * @package install
+ */
+namespace SymphonyCms\Installer\Lib;
+
+class Requirements
+{
     /**
-     * @package install
+     * @return array
      */
-    namespace SymphonyCms\Installer\Lib;
-
-    class Requirements
+    public function check()
     {
-        /**
-         * @return array
-         */
-        public function check()
-        {
-            $errors = array();
+        $errors = array();
 
-            // Check for PHP 5.4+
-            if (version_compare(phpversion(), '5.5.9', '<=')) {
-                $errors[] = array(
-                    'msg' => __('PHP Version is not correct'),
-                    'details' => __('Symphony requires %1$s or greater to work, however version %2$s was detected.',
-                        array(
-                            '<code><abbr title="PHP: Hypertext Pre-processor">PHP</abbr> 5.5.9</code>',
-                            '<code>' . phpversion() . '</code>'
-                        ))
-                );
-            }
-
-            // Is PDO available?
-            if (!extension_loaded('pdo')) {
-                $errors[] = array(
-                    'msg' => __('PDO extension not present'),
-                    'details' => __('Symphony requires PHP to be configured with PDO to work.')
-                );
-            }
-
-            // Is CURL available?
-            if (!extension_loaded('curl')) {
-                $errors[] = array(
-                    'msg' => __('CURL extension not present'),
-                    'details' => __('Symphony requires PHP to be configured with CURL for HTTP communication.')
-                );
-            }
-
-            // Is libxml available?
-            if (!extension_loaded('xml') && !extension_loaded('libxml')) {
-                $errors[] = array(
-                    'msg' => __('XML extension not present'),
-                    'details' => __('Symphony needs the XML extension to pass data to the site frontend.')
-                );
-            }
-
-            // Is libxslt available?
-            if (!extension_loaded('xsl') && !extension_loaded('xslt') && !function_exists('domxml_xslt_stylesheet')) {
-                $errors[] = array(
-                    'msg' => __('XSLT extension not present'),
-                    'details' => __('Symphony needs an XSLT processor such as %s or Sablotron to build pages.',
-                        array('Lib<abbr title="eXtensible Stylesheet Language Transformation">XSLT</abbr>'))
-                );
-            }
-
-            // Is json_encode available?
-            if (!function_exists('json_decode')) {
-                $errors[] = array(
-                    'msg' => __('JSON functionality is not present'),
-                    'details' => __('Symphony uses JSON functionality throughout the backend for translations and the interface.')
-                );
-            }
-
-            // Cannot write to root folder.
-            if (!is_writable(DOCROOT)) {
-                $errors['no-write-permission-root'] = array(
-                    'msg' => 'Root folder not writable: ' . DOCROOT,
-                    'details' => __('Symphony does not have write permission to the root directory. Please modify permission settings on %s. This can be reverted once installation is complete.',
-                        array('<code>' . DOCROOT . '</code>'))
-                );
-            }
-
-            // Cannot write to workspace
-            if (is_dir(DOCROOT . '/workspace') && !is_writable(DOCROOT . '/workspace')) {
-                $errors['no-write-permission-workspace'] = array(
-                    'msg' => 'Workspace folder not writable: ' . DOCROOT . '/workspace',
-                    'details' => __('Symphony does not have write permission to the existing %1$s directory. Please modify permission settings on this directory and its contents to allow this, such as with a recursive %2$s command.',
-                        array('<code>/workspace</code>', '<code>chmod -R</code>'))
-                );
-            }
-
-            return $errors;
+        // Check for PHP 5.4+
+        if (version_compare(phpversion(), '5.5.9', '<=')) {
+            $errors[] = array(
+                'msg' => __('PHP Version is not correct'),
+                'details' => __(
+                    'Symphony requires %1$s or greater to work, however version %2$s was detected.',
+                    array(
+                        '<code><abbr title="PHP: Hypertext Pre-processor">PHP</abbr> 5.5.9</code>',
+                        '<code>' . phpversion() . '</code>'
+                    )
+                )
+            );
         }
+
+        // Is PDO available?
+        if (!extension_loaded('pdo')) {
+            $errors[] = array(
+                'msg' => __('PDO extension not present'),
+                'details' => __('Symphony requires PHP to be configured with PDO to work.')
+            );
+        }
+
+        // Is CURL available?
+        if (!extension_loaded('curl')) {
+            $errors[] = array(
+                'msg' => __('CURL extension not present'),
+                'details' => __('Symphony requires PHP to be configured with CURL for HTTP communication.')
+            );
+        }
+
+        // Is libxml available?
+        if (!extension_loaded('xml') && !extension_loaded('libxml')) {
+            $errors[] = array(
+                'msg' => __('XML extension not present'),
+                'details' => __('Symphony needs the XML extension to pass data to the site frontend.')
+            );
+        }
+
+        // Is libxslt available?
+        if (!extension_loaded('xsl') && !extension_loaded('xslt') && !function_exists('domxml_xslt_stylesheet')) {
+            $errors[] = array(
+                'msg' => __('XSLT extension not present'),
+                'details' => __(
+                    'Symphony needs an XSLT processor such as %s or Sablotron to build pages.',
+                    array('Lib<abbr title="eXtensible Stylesheet Language Transformation">XSLT</abbr>')
+                )
+            );
+        }
+
+        // Is json_encode available?
+        if (!function_exists('json_decode')) {
+            $errors[] = array(
+                'msg' => __('JSON functionality is not present'),
+                'details' => __('Symphony uses JSON functionality throughout the backend for translations and the interface.')
+            );
+        }
+
+        // Cannot write to root folder.
+        if (!is_writable(DOCROOT)) {
+            $errors['no-write-permission-root'] = array(
+                'msg' => 'Root folder not writable: ' . DOCROOT,
+                'details' => __(
+                    'Symphony does not have write permission to the root directory. Please modify permission settings on %s. This can be reverted once installation is complete.',
+                    array('<code>' . DOCROOT . '</code>')
+                )
+            );
+        }
+
+        // Cannot write to workspace
+        if (is_dir(DOCROOT . '/workspace') && !is_writable(DOCROOT . '/workspace')) {
+            $errors['no-write-permission-workspace'] = array(
+                'msg' => 'Workspace folder not writable: ' . DOCROOT . '/workspace',
+                'details' => __(
+                    'Symphony does not have write permission to the existing %1$s directory. Please modify permission settings on this directory and its contents to allow this, such as with a recursive %2$s command.',
+                    array('<code>/workspace</code>', '<code>chmod -R</code>')
+                )
+            );
+        }
+
+        return $errors;
     }
+}

--- a/install/lib/Requirements.php
+++ b/install/lib/Requirements.php
@@ -26,19 +26,19 @@
                 );
             }
 
-            // Is MySQL available?
-            if (!function_exists('mysqli_connect')) {
+            // Is PDO available?
+            if (!function_exists('pdo')) {
                 $errors[] = array(
-                    'msg' => __('MySQLi extension not present'),
-                    'details' => __('Symphony requires PHP to be configured with MySQLi to work.')
+                    'msg' => __('PDO extension not present'),
+                    'details' => __('Symphony requires PHP to be configured with PDO to work.')
                 );
             }
 
-            // Is ZLib available?
-            if (!extension_loaded('zlib')) {
+            // Is CURL available?
+            if (!function_exists('curl')) {
                 $errors[] = array(
-                    'msg' => __('ZLib extension not present'),
-                    'details' => __('Symphony uses the ZLib compression library for log rotation.')
+                    'msg' => __('CURL extension not present'),
+                    'details' => __('Symphony requires PHP to be configured with CURL for HTTP communication.')
                 );
             }
 

--- a/install/lib/Updater.php
+++ b/install/lib/Updater.php
@@ -1,4 +1,15 @@
 <?php
+    /**
+     * @package install
+     */
+    namespace SymphonyCms\Installer\Lib;
+
+    use DatabaseException;
+    use DirectoryIterator;
+    use Exception;
+    use General;
+    use Lang;
+    use Symphony;
 
     class Updater extends Installer
     {
@@ -102,7 +113,7 @@
 
                 // Include migration so we can see what the version is
                 include_once($m->getPathname());
-                $classname = 'migration_' . str_replace('.', '', $version);
+                $classname = 'SymphonyCms\\Installer\\Migrations\\migration_' . str_replace('.', '', $version);
 
                 $m = new $classname();
 

--- a/install/lib/Updater.php
+++ b/install/lib/Updater.php
@@ -1,195 +1,204 @@
 <?php
+/**
+ * @package install
+ */
+namespace SymphonyCms\Installer\Lib;
+
+use DatabaseException;
+use DirectoryIterator;
+use Exception;
+use General;
+use Lang;
+use Symphony;
+
+class Updater extends Installer
+{
     /**
-     * @package install
+     * This function returns an instance of the Updater class. It is the only way to
+     * create a new Updater, as it implements the Singleton interface
+     *
+     * @return Updater
      */
-    namespace SymphonyCms\Installer\Lib;
-
-    use DatabaseException;
-    use DirectoryIterator;
-    use Exception;
-    use General;
-    use Lang;
-    use Symphony;
-
-    class Updater extends Installer
+    public static function instance()
     {
-        /**
-         * This function returns an instance of the Updater
-         * class. It is the only way to create a new Updater, as
-         * it implements the Singleton interface
-         *
-         * @return Updater
-         */
-        public static function instance()
-        {
-            if (!(self::$_instance instanceof Updater)) {
-                self::$_instance = new Updater;
+        if (!(self::$_instance instanceof Updater)) {
+            self::$_instance = new Updater;
+        }
+
+        return self::$_instance;
+    }
+
+    /**
+     * Initialises the language by looking at the existing configuration
+     */
+    public static function initialiseLang()
+    {
+        Lang::set(Symphony::Configuration()->get('lang', 'symphony'), false);
+    }
+
+    /**
+     * Initialises the configuration object by loading the existing
+     * website config file
+     *
+     * @param array $data
+     */
+    public static function initialiseConfiguration(array $data = array())
+    {
+        parent::initialiseConfiguration();
+    }
+
+    /**
+     * Overrides the `initialiseLog()` method and writes logs to `manifest/logs/update`
+     *
+     * @param string $filename
+     * @return bool|void
+     * @throws Exception
+     */
+    public static function initialiseLog($filename = null)
+    {
+        if (is_dir(INSTALL_LOGS) || General::realiseDirectory(
+            INSTALL_LOGS,
+            self::Configuration()->get('write_mode', 'directory')
+        )
+        ) {
+            parent::initialiseLog(INSTALL_LOGS . '/update');
+        }
+    }
+
+    /**
+     * Overrides the default `initialiseDatabase()` method
+     * This allows us to still use the normal accessor
+     */
+    public static function initialiseDatabase()
+    {
+        self::setDatabase();
+
+        $details = Symphony::Configuration()->get('database');
+
+        try {
+            Symphony::Database()->connect(
+                $details['host'],
+                $details['user'],
+                $details['password'],
+                $details['port'],
+                $details['db']
+            );
+        } catch (DatabaseException $e) {
+            self::__abort(
+                'There was a problem while trying to establish a connection to the MySQL server. Please check your settings.',
+                time()
+            );
+        }
+
+        // MySQL: Setting prefix & character encoding
+        Symphony::Database()->setPrefix($details['tbl_prefix']);
+    }
+
+    public function run()
+    {
+        // Initialize log
+        if (is_null(Symphony::Log())) {
+            self::__render(new UpdaterPage('missing-log'));
+        }
+
+        // Get available migrations. This will only contain the migrations
+        // that are applicable to the current install.
+        $migrations = array();
+
+        foreach (new DirectoryIterator(INSTALL . '/migrations') as $m) {
+            if ($m->isDot() || $m->isDir() || General::getExtension($m->getFilename()) !== 'php') {
+                continue;
             }
 
-            return self::$_instance;
-        }
+            $version = str_replace('.php', '', $m->getFilename());
 
-        /**
-         * Initialises the language by looking at the existing
-         * configuration
-         */
-        public static function initialiseLang()
-        {
-            Lang::set(Symphony::Configuration()->get('lang', 'symphony'), false);
-        }
+            // Include migration so we can see what the version is
+            include_once($m->getPathname());
+            $classname = 'SymphonyCms\\Installer\\Migrations\\migration_' . str_replace('.', '', $version);
 
-        /**
-         * Initialises the configuration object by loading the existing
-         * website config file
-         *
-         * @param array $data
-         */
-        public static function initialiseConfiguration(array $data = array())
-        {
-            parent::initialiseConfiguration();
-        }
+            $m = new $classname();
 
-        /**
-         * Overrides the `initialiseLog()` method and writes
-         * logs to manifest/logs/update
-         *
-         * @param string $filename
-         * @return bool|void
-         * @throws Exception
-         */
-        public static function initialiseLog($filename = null)
-        {
-            if (is_dir(INSTALL_LOGS) || General::realiseDirectory(INSTALL_LOGS, self::Configuration()->get('write_mode', 'directory'))) {
-                parent::initialiseLog(INSTALL_LOGS . '/update');
+            if (version_compare(
+                Symphony::Configuration()->get('version', 'symphony'),
+                call_user_func(array($m, 'getVersion')),
+                '<'
+            )) {
+                $migrations[call_user_func(array($m, 'getVersion'))] = $m;
             }
         }
 
-        /**
-         * Overrides the default `initialiseDatabase()` method
-         * This allows us to still use the normal accessor
-         */
-        public static function initialiseDatabase()
-        {
-            self::setDatabase();
+        // The DirectoryIterator may return files in a sporadic order
+        // on different servers. This will ensure the array is sorted
+        // correctly using `version_compare`
+        uksort($migrations, 'version_compare');
 
-            $details = Symphony::Configuration()->get('database');
+        // If there are no applicable migrations then this is up to date
+        if (empty($migrations)) {
+            Symphony::Log()->info('Updater - Already up-to-date');
 
-            try {
-                Symphony::Database()->connect(
-                    $details['host'],
-                    $details['user'],
-                    $details['password'],
-                    $details['port'],
-                    $details['db']
+            self::__render(new UpdaterPage('uptodate'));
+        } // Show start page
+        elseif (!isset($_POST['action']['update'])) {
+            $notes = array();
+
+            // Loop over all available migrations showing there
+            // pre update notes.
+            foreach ($migrations as $version => $m) {
+                $n = call_user_func(array($m, 'preUpdateNotes'));
+                if (!empty($n)) {
+                    $notes[$version] = $n;
+                }
+            }
+
+            // Show the update ready page, which will display the
+            // version and release notes of the most recent migration
+            self::__render(new UpdaterPage('ready', array(
+                'pre-notes' => $notes,
+                'version' => call_user_func(array($m, 'getVersion')),
+                'release-notes' => call_user_func(array($m, 'getReleaseNotes'))
+            )));
+        } // Upgrade Symphony
+        else {
+            $notes = array();
+            $canProceed = true;
+
+            // Loop over all the available migrations incrementally applying
+            // the upgrades. If any upgrade throws an uncaught exception or
+            // returns false, this will break and the failure page shown
+            foreach ($migrations as $version => $m) {
+                $n = call_user_func(array($m, 'postUpdateNotes'));
+                if (!empty($n)) {
+                    $notes[$version] = $n;
+                }
+
+                $canProceed = call_user_func(
+                    array($m, 'run'),
+                    'upgrade',
+                    Symphony::Configuration()->get('version', 'symphony')
                 );
-            } catch (DatabaseException $e) {
-                self::__abort(
-                    'There was a problem while trying to establish a connection to the MySQL server. Please check your settings.',
-                    time()
+
+                Symphony::Log()->info(
+                    sprintf(
+                        'Updater - Migration to %s was %s',
+                        $version,
+                        $canProceed ? 'successful' : 'unsuccessful'
+                    )
                 );
-            }
 
-            // MySQL: Setting prefix & character encoding
-            Symphony::Database()->setPrefix($details['tbl_prefix']);
-        }
-
-        public function run()
-        {
-            // Initialize log
-            if (is_null(Symphony::Log())) {
-                self::__render(new UpdaterPage('missing-log'));
-            }
-
-            // Get available migrations. This will only contain the migrations
-            // that are applicable to the current install.
-            $migrations = array();
-
-            foreach (new DirectoryIterator(INSTALL . '/migrations') as $m) {
-                if ($m->isDot() || $m->isDir() || General::getExtension($m->getFilename()) !== 'php') {
-                    continue;
-                }
-
-                $version = str_replace('.php', '', $m->getFilename());
-
-                // Include migration so we can see what the version is
-                include_once($m->getPathname());
-                $classname = 'SymphonyCms\\Installer\\Migrations\\migration_' . str_replace('.', '', $version);
-
-                $m = new $classname();
-
-                if (version_compare(Symphony::Configuration()->get('version', 'symphony'), call_user_func(array($m, 'getVersion')), '<')) {
-                    $migrations[call_user_func(array($m, 'getVersion'))] = $m;
+                if (!$canProceed) {
+                    break;
                 }
             }
 
-            // The DirectoryIterator may return files in a sporatic order
-            // on different servers. This will ensure the array is sorted
-            // correctly using `version_compare`
-            uksort($migrations, 'version_compare');
-
-            // If there are no applicable migrations then this is up to date
-            if (empty($migrations)) {
-                Symphony::Log()->info('Updater - Already up-to-date');
-
-                self::__render(new UpdaterPage('uptodate'));
-            }
-
-            // Show start page
-            elseif (!isset($_POST['action']['update'])) {
-                $notes = array();
-
-                // Loop over all available migrations showing there
-                // pre update notes.
-                foreach ($migrations as $version => $m) {
-                    $n = call_user_func(array($m, 'preUpdateNotes'));
-                    if (!empty($n)) {
-                        $notes[$version] = $n;
-                    }
-                }
-
-                // Show the update ready page, which will display the
-                // version and release notes of the most recent migration
-                self::__render(new UpdaterPage('ready', array(
-                    'pre-notes' => $notes,
+            if (!$canProceed) {
+                self::__render(new UpdaterPage('failure'));
+            } else {
+                self::__render(new UpdaterPage('success', array(
+                    'post-notes' => $notes,
                     'version' => call_user_func(array($m, 'getVersion')),
                     'release-notes' => call_user_func(array($m, 'getReleaseNotes'))
                 )));
             }
-
-            // Upgrade Symphony
-            else {
-                $notes = array();
-                $canProceed = true;
-
-                // Loop over all the available migrations incrementally applying
-                // the upgrades. If any upgrade throws an uncaught exception or
-                // returns false, this will break and the failure page shown
-                foreach ($migrations as $version => $m) {
-                    $n = call_user_func(array($m, 'postUpdateNotes'));
-                    if (!empty($n)) {
-                        $notes[$version] = $n;
-                    }
-
-                    $canProceed = call_user_func(array($m, 'run'), 'upgrade', Symphony::Configuration()->get('version', 'symphony'));
-
-                    Symphony::Log()->info(
-                        sprintf('Updater - Migration to %s was %s', $version, $canProceed ? 'successful' : 'unsuccessful')
-                    );
-
-                    if (!$canProceed) {
-                        break;
-                    }
-                }
-
-                if (!$canProceed) {
-                    self::__render(new UpdaterPage('failure'));
-                } else {
-                    self::__render(new UpdaterPage('success', array(
-                        'post-notes' => $notes,
-                        'version' => call_user_func(array($m, 'getVersion')),
-                        'release-notes' => call_user_func(array($m, 'getReleaseNotes'))
-                    )));
-                }
-            }
         }
     }
+}

--- a/install/lib/UpdaterPage.php
+++ b/install/lib/UpdaterPage.php
@@ -1,8 +1,14 @@
 <?php
 
     /**
-     * @package content
+     * @package install
      */
+    namespace SymphonyCms\Installer\Lib;
+
+    use Exception;
+    use Symphony;
+    use Widget;
+    use XMLElement;
 
     class UpdaterPage extends InstallerPage
     {
@@ -87,16 +93,11 @@
             $h2 = new XMLElement('h2', __('Updating Failure'));
             $p = new XMLElement('p', __('An error occurred while updating Symphony.'));
 
-            // Attempt to get update information from the log file
+            // Attempt to get update information from the log fileØ
             try {
                 $log = file_get_contents(INSTALL_LOGS . '/update');
             } catch (Exception $ex) {
-                $log_entry = Symphony::Log()->popFromLog();
-                if (isset($log_entry['message'])) {
-                    $log = $log_entry['message'];
-                } else {
-                    $log = 'Unknown error occurred when reading the update log';
-                }
+                $log = (string)$ex;
             }
 
             $code = new XMLElement('code', $log);

--- a/install/lib/UpdaterPage.php
+++ b/install/lib/UpdaterPage.php
@@ -1,150 +1,168 @@
 <?php
 
-    /**
-     * @package install
-     */
-    namespace SymphonyCms\Installer\Lib;
+/**
+ * @package install
+ */
+namespace SymphonyCms\Installer\Lib;
 
-    use Exception;
-    use Symphony;
-    use Widget;
-    use XMLElement;
+use Exception;
+use Symphony;
+use Widget;
+use XMLElement;
 
-    class UpdaterPage extends InstallerPage
+class UpdaterPage extends InstallerPage
+{
+    public function __construct($template, $params = array())
     {
-        public function __construct($template, $params = array())
-        {
-            parent::__construct($template, $params);
+        parent::__construct($template, $params);
 
-            $this->_template = $template;
-            $this->_page_title = __('Update Symphony');
-        }
+        $this->_template = $template;
+        $this->_page_title = __('Update Symphony');
+    }
 
-        protected function __build($version = VERSION, XMLElement $extra = null)
-        {
-            parent::__build(
-                // Replace the installed version with the updated version
-                isset($this->_params['version'])
-                    ? $this->_params['version']
-                    : Symphony::Configuration()->get('version', 'symphony')
-            );
+    protected function __build($version = VERSION, XMLElement $extra = null)
+    {
+        parent::__build(
+            // Replace the installed version with the updated version
+            isset($this->_params['version'])
+                ? $this->_params['version']
+                : Symphony::Configuration()->get('version', 'symphony')
+        );
 
-            // Add Release Notes for the latest migration
-            if (isset($this->_params['release-notes'])) {
-                $nodeset = $this->Form->getChildrenByName('h1');
-                $h1 = end($nodeset);
-                if ($h1 instanceof XMLElement) {
-                    $h1->appendChild(
-                        new XMLElement(
-                            'em',
-                            Widget::Anchor(__('Release Notes'), $this->_params['release-notes'])
-                        )
-                    );
-                }
-            }
-        }
-
-        protected function viewUptodate()
-        {
-            $h2 = new XMLElement('h2', __('Symphony is already up-to-date'));
-            $p = new XMLElement('p', __('It appears that Symphony has already been installed at this location and is up to date.'));
-
-            $this->Form->appendChild($h2);
-            $this->Form->appendChild($p);
-        }
-
-        protected function viewReady()
-        {
-            $h2 = new XMLElement('h2', __('Updating Symphony'));
-            $p = new XMLElement('p', __('This script will update your existing Symphony installation to version %s.', array('<code>' . $this->_params['version'] . '</code>')));
-
-            $this->Form->appendChild($h2);
-            $this->Form->appendChild($p);
-
-            if (!is_writable(CONFIG)) {
-                $this->Form->appendChild(
-                    new XMLElement('p', __('Please check that your configuration file is writable before proceeding'), array('class' => 'warning'))
+        // Add Release Notes for the latest migration
+        if (isset($this->_params['release-notes'])) {
+            $nodeset = $this->Form->getChildrenByName('h1');
+            $h1 = end($nodeset);
+            if ($h1 instanceof XMLElement) {
+                $h1->appendChild(
+                    new XMLElement(
+                        'em',
+                        Widget::Anchor(__('Release Notes'), $this->_params['release-notes'])
+                    )
                 );
             }
+        }
+    }
 
-            if (!empty($this->_params['pre-notes'])) {
-                $h2 = new XMLElement('h2', __('Pre-Installation Notes:'));
-                $dl = new XMLElement('dl');
+    protected function viewUptodate()
+    {
+        $h2 = new XMLElement('h2', __('Symphony is already up-to-date'));
+        $p = new XMLElement(
+            'p',
+            __('It appears that Symphony has already been installed at this location and is up to date.')
+        );
 
-                foreach ($this->_params['pre-notes'] as $version => $notes) {
+        $this->Form->appendChild($h2);
+        $this->Form->appendChild($p);
+    }
+
+    protected function viewReady()
+    {
+        $h2 = new XMLElement('h2', __('Updating Symphony'));
+        $p = new XMLElement('p', __(
+            'This script will update your existing Symphony installation to version %s.',
+            array('<code>' . $this->_params['version'] . '</code>')
+        ));
+
+        $this->Form->appendChild($h2);
+        $this->Form->appendChild($p);
+
+        if (!is_writable(CONFIG)) {
+            $this->Form->appendChild(
+                new XMLElement(
+                    'p',
+                    __('Please check that your configuration file is writable before proceeding'),
+                    array('class' => 'warning')
+                )
+            );
+        }
+
+        if (!empty($this->_params['pre-notes'])) {
+            $h2 = new XMLElement('h2', __('Pre-Installation Notes:'));
+            $dl = new XMLElement('dl');
+
+            foreach ($this->_params['pre-notes'] as $version => $notes) {
+                $dl->appendChild(new XMLElement('dt', $version));
+                foreach ($notes as $note) {
+                    $dl->appendChild(new XMLElement('dd', $note));
+                }
+            }
+
+            $this->Form->appendChild($h2);
+            $this->Form->appendChild($dl);
+        }
+
+        $submit = new XMLElement('div', null, array('class' => 'submit'));
+        $submit->appendChild(Widget::Input('action[update]', __('Update Symphony'), 'submit'));
+
+        $this->Form->appendChild($submit);
+    }
+
+    protected function viewFailure()
+    {
+        $h2 = new XMLElement('h2', __('Updating Failure'));
+        $p = new XMLElement('p', __('An error occurred while updating Symphony.'));
+
+        // Attempt to get update information from the log fileØ
+        try {
+            $log = file_get_contents(INSTALL_LOGS . '/update');
+        } catch (Exception $ex) {
+            $log = (string)$ex;
+        }
+
+        $code = new XMLElement('code', $log);
+
+        $this->Form->appendChild($h2);
+        $this->Form->appendChild($p);
+        $this->Form->appendChild(
+            new XMLElement('pre', $code)
+        );
+    }
+
+    protected function viewSuccess()
+    {
+        $this->Form->setAttribute('action', SYMPHONY_URL);
+
+        $h2 = new XMLElement('h2', __('Updating Complete'));
+        $this->Form->appendChild($h2);
+
+        if (!empty($this->_params['post-notes'])) {
+            $dl = new XMLElement('dl');
+
+            foreach ($this->_params['post-notes'] as $version => $notes) {
+                if ($notes) {
                     $dl->appendChild(new XMLElement('dt', $version));
                     foreach ($notes as $note) {
                         $dl->appendChild(new XMLElement('dd', $note));
                     }
                 }
-
-                $this->Form->appendChild($h2);
-                $this->Form->appendChild($dl);
             }
 
-            $submit = new XMLElement('div', null, array('class' => 'submit'));
-            $submit->appendChild(Widget::Input('action[update]', __('Update Symphony'), 'submit'));
-
-            $this->Form->appendChild($submit);
+            $this->Form->appendChild($dl);
         }
 
-        protected function viewFailure()
-        {
-            $h2 = new XMLElement('h2', __('Updating Failure'));
-            $p = new XMLElement('p', __('An error occurred while updating Symphony.'));
-
-            // Attempt to get update information from the log fileØ
-            try {
-                $log = file_get_contents(INSTALL_LOGS . '/update');
-            } catch (Exception $ex) {
-                $log = (string)$ex;
-            }
-
-            $code = new XMLElement('code', $log);
-
-            $this->Form->appendChild($h2);
-            $this->Form->appendChild($p);
-            $this->Form->appendChild(
-                new XMLElement('pre', $code)
-            );
-        }
-
-        protected function viewSuccess()
-        {
-            $this->Form->setAttribute('action', SYMPHONY_URL);
-
-            $h2 = new XMLElement('h2', __('Updating Complete'));
-            $this->Form->appendChild($h2);
-
-            if (!empty($this->_params['post-notes'])) {
-                $dl = new XMLElement('dl');
-
-                foreach ($this->_params['post-notes'] as $version => $notes) {
-                    if ($notes) {
-                        $dl->appendChild(new XMLElement('dt', $version));
-                        foreach ($notes as $note) {
-                            $dl->appendChild(new XMLElement('dd', $note));
-                        }
-                    }
-                }
-
-                $this->Form->appendChild($dl);
-            }
-
-            $this->Form->appendChild(
-                new XMLElement('p',
-                    __('And the crowd goes wild! A victory dance is in order; and look, your mum is watching. She\'s proud.', array(Symphony::Configuration()->get('sitename', 'general')))
+        $this->Form->appendChild(
+            new XMLElement(
+                'p',
+                __(
+                    'And the crowd goes wild! A victory dance is in order; and look, your mum is watching. She\'s proud.',
+                    array(Symphony::Configuration()->get('sitename', 'general'))
                 )
-            );
-            $this->Form->appendChild(
-                new XMLElement('p',
-                    __('Your mum is also nagging you about removing that %s directory before you log in.', array('<code>' . basename(INSTALL_URL) . '</code>'))
+            )
+        );
+        $this->Form->appendChild(
+            new XMLElement(
+                'p',
+                __(
+                    'Your mum is also nagging you about removing that %s directory before you log in.',
+                    array('<code>' . basename(INSTALL_URL) . '</code>')
                 )
-            );
+            )
+        );
 
-            $submit = new XMLElement('div', null, array('class' => 'submit'));
-            $submit->appendChild(Widget::Input('submit', __('Complete'), 'submit'));
+        $submit = new XMLElement('div', null, array('class' => 'submit'));
+        $submit->appendChild(Widget::Input('submit', __('Complete'), 'submit'));
 
-            $this->Form->appendChild($submit);
-        }
+        $this->Form->appendChild($submit);
     }
+}

--- a/install/lib/class.installerpage.php
+++ b/install/lib/class.installerpage.php
@@ -157,12 +157,7 @@
             try {
                 $log = file_get_contents(INSTALL_LOGS . '/install');
             } catch (Exception $ex) {
-                $log_entry = Symphony::Log()->popFromLog();
-                if (isset($log_entry['message'])) {
-                    $log = $log_entry['message'];
-                } else {
-                    $log = 'Unknown error occurred when reading the install log';
-                }
+                $log = (string)$ex;
             }
 
             $code = new XMLElement('code', $log);

--- a/install/lib/class.installerpage.php
+++ b/install/lib/class.installerpage.php
@@ -6,11 +6,11 @@
 
     class InstallerPage extends HTMLPage
     {
-        private $_template;
-
         protected $_params;
 
         protected $_page_title;
+
+        protected $_template;
 
         public function __construct($template, $params = array())
         {
@@ -157,6 +157,7 @@
             try {
                 $log = file_get_contents(INSTALL_LOGS . '/install');
             } catch (Exception $ex) {
+                var_dump($ex);
                 $log_entry = Symphony::Log()->popFromLog();
                 if (isset($log_entry['message'])) {
                     $log = $log_entry['message'];

--- a/install/lib/class.installerpage.php
+++ b/install/lib/class.installerpage.php
@@ -157,7 +157,6 @@
             try {
                 $log = file_get_contents(INSTALL_LOGS . '/install');
             } catch (Exception $ex) {
-                var_dump($ex);
                 $log_entry = Symphony::Log()->popFromLog();
                 if (isset($log_entry['message'])) {
                     $log = $log_entry['message'];
@@ -220,16 +219,17 @@
         protected function viewConfiguration()
         {
             /* -----------------------------------------------
-         * Populating fields array
-         * -----------------------------------------------
-         */
+             * Populating fields array
+             * -----------------------------------------------
+             */
 
             $fields = isset($_POST['fields']) ? $_POST['fields'] : $this->_params['default-config'];
 
-        /* -----------------------------------------------
-         * Welcome
-         * -----------------------------------------------
-         */
+            /* -----------------------------------------------
+             * Welcome
+             * -----------------------------------------------
+             */
+
             $div = new XMLElement('div');
             $div->appendChild(
                 new XMLElement('h2', __('Find something sturdy to hold on to because things are about to get awesome.'))

--- a/install/migrations/2.2.0.php
+++ b/install/migrations/2.2.0.php
@@ -1,5 +1,11 @@
 <?php
 
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
+    use Exception;
+
     class migration_220 extends Migration
     {
         public static function getVersion()

--- a/install/migrations/2.2.0.php
+++ b/install/migrations/2.2.0.php
@@ -1,80 +1,80 @@
 <?php
 
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
-    use Exception;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
+use Exception;
 
-    class migration_220 extends Migration
+class migration_220 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.2';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.2/';
-        }
-
-        public static function upgrade()
-        {
-            // 2.2.0dev
-            if (version_compare(self::$existing_version, '2.2.0dev', '<=')) {
-                Symphony::Configuration()->set('version', '2.2dev', 'symphony');
-                if (Symphony::Database()->tableContainsField('tbl_sections_association', 'cascading_deletion')) {
-                    Symphony::Database()->query(
-                        'ALTER TABLE `tbl_sections_association` CHANGE  `cascading_deletion` `hide_association` enum("yes","no") COLLATE utf8_unicode_ci NOT NULL DEFAULT "no";'
-                    );
-
-                    // Update Select table to include the new association field
-                    Symphony::Database()->query('ALTER TABLE `tbl_fields_select` ADD `show_association` ENUM( "yes", "no" ) COLLATE utf8_unicode_ci NOT NULL DEFAULT "yes"');
-                }
-
-                if (Symphony::Database()->tableContainsField('tbl_authors', 'default_section')) {
-                    // Allow Authors to be set to any area in the backend.
-                    Symphony::Database()->query(
-                        'ALTER TABLE `tbl_authors` CHANGE `default_section` `default_area` VARCHAR(255) COLLATE utf8_unicode_ci DEFAULT NULL;'
-                    );
-                }
-                Symphony::Configuration()->write();
-            }
-
-            // 2.2.0
-            if (version_compare(self::$existing_version, '2.2', '<=')) {
-                Symphony::Configuration()->set('version', '2.2', 'symphony');
-                Symphony::Configuration()->set('datetime_separator', ' ', 'region');
-                Symphony::Configuration()->set('strict_error_handling', 'yes', 'symphony');
-
-                // We've added UNIQUE KEY indexes to the Author, Checkbox, Date, Input, Textarea and Upload Fields
-                // Time to go through the entry tables and make this change as well.
-                $author = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_author`");
-                $checkbox = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_checkbox`");
-                $date = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_date`");
-                $input = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_input`");
-                $textarea = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_textarea`");
-                $upload = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_upload`");
-
-                $field_ids = array_merge($author, $checkbox, $date, $input, $textarea, $upload);
-
-                foreach ($field_ids as $id) {
-                    $table = '`tbl_entries_data_' . $id . '`';
-
-                    try {
-                        Symphony::Database()->query("ALTER TABLE " . $table . " DROP INDEX `entry_id`");
-                    } catch (Exception $ex) {
-                    }
-
-                    try {
-                        Symphony::Database()->query("CREATE UNIQUE INDEX `entry_id` ON " . $table . " (`entry_id`)");
-                        Symphony::Database()->query("OPTIMIZE TABLE " . $table);
-                    } catch (Exception $ex) {
-                    }
-                }
-            }
-
-            // Update the version information
-            return parent::upgrade();
-        }
+        return '2.2';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.2/';
+    }
+
+    public static function upgrade()
+    {
+        // 2.2.0dev
+        if (version_compare(self::$existing_version, '2.2.0dev', '<=')) {
+            Symphony::Configuration()->set('version', '2.2dev', 'symphony');
+            if (Symphony::Database()->tableContainsField('tbl_sections_association', 'cascading_deletion')) {
+                Symphony::Database()->query(
+                    'ALTER TABLE `tbl_sections_association` CHANGE  `cascading_deletion` `hide_association` ENUM("yes","no") COLLATE utf8_unicode_ci NOT NULL DEFAULT "no";'
+                );
+            }
+
+            // Update Select table to include the new association field
+            Symphony::Database()->query('ALTER TABLE `tbl_fields_select` ADD `show_association` ENUM( "yes", "no" ) COLLATE utf8_unicode_ci NOT NULL DEFAULT "yes"');
+
+            if (Symphony::Database()->tableContainsField('tbl_authors', 'default_section')) {
+                // Allow Authors to be set to any area in the backend.
+                Symphony::Database()->query(
+                    'ALTER TABLE `tbl_authors` CHANGE `default_section` `default_area` VARCHAR(255) COLLATE utf8_unicode_ci DEFAULT NULL;'
+                );
+            }
+            Symphony::Configuration()->write();
+        }
+
+        // 2.2.0
+        if (version_compare(self::$existing_version, '2.2', '<=')) {
+            Symphony::Configuration()->set('version', '2.2', 'symphony');
+            Symphony::Configuration()->set('datetime_separator', ' ', 'region');
+            Symphony::Configuration()->set('strict_error_handling', 'yes', 'symphony');
+
+            // We've added UNIQUE KEY indexes to the Author, Checkbox, Date, Input, Textarea and Upload Fields
+            // Time to go through the entry tables and make this change as well.
+            $author = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_author`");
+            $checkbox = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_checkbox`");
+            $date = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_date`");
+            $input = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_input`");
+            $textarea = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_textarea`");
+            $upload = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_upload`");
+
+            $field_ids = array_merge($author, $checkbox, $date, $input, $textarea, $upload);
+
+            foreach ($field_ids as $id) {
+                $table = '`tbl_entries_data_' . $id . '`';
+
+                try {
+                    Symphony::Database()->query("ALTER TABLE " . $table . " DROP INDEX `entry_id`");
+                } catch (Exception $ex) {
+                }
+
+                try {
+                    Symphony::Database()->query("CREATE UNIQUE INDEX `entry_id` ON " . $table . " (`entry_id`)");
+                    Symphony::Database()->query("OPTIMIZE TABLE " . $table);
+                } catch (Exception $ex) {
+                }
+            }
+        }
+
+        // Update the version information
+        return parent::upgrade();
+    }
+}

--- a/install/migrations/2.2.1.php
+++ b/install/migrations/2.2.1.php
@@ -1,4 +1,9 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
+    use Exception;
 
     class migration_221 extends Migration
     {

--- a/install/migrations/2.2.1.php
+++ b/install/migrations/2.2.1.php
@@ -1,115 +1,129 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
-    use Exception;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
+use Exception;
 
-    class migration_221 extends Migration
+class migration_221 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.2.1';
+        return '2.2.1';
+    }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.2.1/';
+    }
+
+    public static function upgrade()
+    {
+        // 2.2.1 Beta 1
+        if (version_compare(self::$existing_version, '2.2.1 Beta 1', '<=')) {
+            Symphony::Configuration()->set('version', '2.2.1 Beta 1', 'symphony');
+            try {
+                Symphony::Database()->query('CREATE INDEX `session_expires` ON `tbl_sessions` (`session_expires`)');
+                Symphony::Database()->query('OPTIMIZE TABLE `tbl_sessions`');
+            } catch (Exception $ex) {
+            }
+            Symphony::Configuration()->write();
         }
 
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.2.1/';
-        }
+        // 2.2.1 Beta 2
+        if (version_compare(self::$existing_version, '2.2.1 Beta 2', '<=')) {
+            Symphony::Configuration()->set('version', '2.2.1 Beta 2', 'symphony');
 
-        public static function upgrade()
-        {
-            // 2.2.1 Beta 1
-            if (version_compare(self::$existing_version, '2.2.1 Beta 1', '<=')) {
-                Symphony::Configuration()->set('version', '2.2.1 Beta 1', 'symphony');
-                try {
-                    Symphony::Database()->query('CREATE INDEX `session_expires` ON `tbl_sessions` (`session_expires`)');
-                    Symphony::Database()->query('OPTIMIZE TABLE `tbl_sessions`');
-                } catch (Exception $ex) {
+            // Add Security Rules from 2.2 to .htaccess
+            try {
+                $htaccess = file_get_contents(DOCROOT . '/.htaccess');
+
+                if ($htaccess !== false && !preg_match('/### SECURITY - Protect crucial files/', $htaccess)) {
+                    $security = '
+        ### SECURITY - Protect crucial files
+        RewriteRule ^manifest/(.*)$ - [F]
+        RewriteRule ^workspace/(pages|utilities)/(.*)\.xsl$ - [F]
+        RewriteRule ^(.*)\.sql$ - [F]
+        RewriteRule (^|/)\. - [F]
+
+        ### DO NOT APPLY RULES WHEN REQUESTING "favicon.ico"';
+
+                    $htaccess = str_replace(
+                        '### DO NOT APPLY RULES WHEN REQUESTING "favicon.ico"',
+                        $security,
+                        $htaccess
+                    );
+                    file_put_contents(DOCROOT . '/.htaccess', $htaccess);
                 }
-                Symphony::Configuration()->write();
+            } catch (Exception $ex) {
             }
 
-            // 2.2.1 Beta 2
-            if (version_compare(self::$existing_version, '2.2.1 Beta 2', '<=')) {
-                Symphony::Configuration()->set('version', '2.2.1 Beta 2', 'symphony');
+            // Add correct index to the `tbl_cache`
+            try {
+                Symphony::Database()->query('ALTER TABLE `tbl_cache` DROP INDEX `creation`');
+                Symphony::Database()->query('CREATE INDEX `expiry` ON `tbl_cache` (`expiry`)');
+                Symphony::Database()->query('OPTIMIZE TABLE `tbl_cache`');
+            } catch (Exception $ex) {
+            }
 
-                // Add Security Rules from 2.2 to .htaccess
-                try {
-                    $htaccess = file_get_contents(DOCROOT . '/.htaccess');
+            // Remove Hide Association field from Select Data tables
+            $select_tables = Symphony::Database()->fetchCol(
+                "field_id",
+                "SELECT `field_id` FROM `tbl_fields_select`"
+            );
 
-                    if ($htaccess !== false && !preg_match('/### SECURITY - Protect crucial files/', $htaccess)) {
-                        $security = '
-            ### SECURITY - Protect crucial files
-            RewriteRule ^manifest/(.*)$ - [F]
-            RewriteRule ^workspace/(pages|utilities)/(.*)\.xsl$ - [F]
-            RewriteRule ^(.*)\.sql$ - [F]
-            RewriteRule (^|/)\. - [F]
-
-            ### DO NOT APPLY RULES WHEN REQUESTING "favicon.ico"';
-
-                        $htaccess = str_replace('### DO NOT APPLY RULES WHEN REQUESTING "favicon.ico"', $security, $htaccess);
-                        file_put_contents(DOCROOT . '/.htaccess', $htaccess);
-                    }
-                } catch (Exception $ex) {
-                }
-
-                // Add correct index to the `tbl_cache`
-                try {
-                    Symphony::Database()->query('ALTER TABLE `tbl_cache` DROP INDEX `creation`');
-                    Symphony::Database()->query('CREATE INDEX `expiry` ON `tbl_cache` (`expiry`)');
-                    Symphony::Database()->query('OPTIMIZE TABLE `tbl_cache`');
-                } catch (Exception $ex) {
-                }
-
-                // Remove Hide Association field from Select Data tables
-                $select_tables = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_select`");
-
-                if (is_array($select_tables) && !empty($select_tables)) {
-                    foreach ($select_tables as $field) {
-                        if (Symphony::Database()->tableContainsField('tbl_entries_data_' . $field, 'show_association')) {
-                            Symphony::Database()->query(sprintf(
+            if (is_array($select_tables) && !empty($select_tables)) {
+                foreach ($select_tables as $field) {
+                    if (Symphony::Database()->tableContainsField(
+                        'tbl_entries_data_' . $field,
+                        'show_association'
+                    )
+                    ) {
+                        Symphony::Database()->query(sprintf(
                             "ALTER TABLE `tbl_entries_data_%d` DROP `show_association`",
                             $field
                         ));
-                        }
                     }
                 }
-
-                // Update Select table to include the sorting option
-                if (!Symphony::Database()->tableContainsField('tbl_fields_select', 'sort_options')) {
-                    Symphony::Database()->query('ALTER TABLE `tbl_fields_select` ADD `sort_options` ENUM( "yes", "no" ) COLLATE utf8_unicode_ci NOT NULL DEFAULT "no"');
-                }
-
-                // Remove the 'driver' from the Config
-                Symphony::Configuration()->remove('driver', 'database');
-                Symphony::Configuration()->write();
-
-                // Remove the NOT NULL from the Author tables
-                try {
-                    $author = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_author`");
-
-                    foreach ($author as $id) {
-                        $table = '`tbl_entries_data_' . $id . '`';
-
-                        Symphony::Database()->query(
-                            'ALTER TABLE ' . $table . ' CHANGE `author_id` `author_id` int(11) unsigned NULL'
-                        );
-                    }
-                } catch (Exception $ex) {
-                }
-
-                Symphony::Configuration()->write();
             }
 
-            // Update the version information
-            return parent::upgrade();
+            // Update Select table to include the sorting option
+            if (!Symphony::Database()->tableContainsField('tbl_fields_select', 'sort_options')) {
+                Symphony::Database()->query('ALTER TABLE `tbl_fields_select` ADD `sort_options` ENUM( "yes", "no" ) COLLATE utf8_unicode_ci NOT NULL DEFAULT "no"');
+            }
+
+            // Remove the 'driver' from the Config
+            Symphony::Configuration()->remove('driver', 'database');
+            Symphony::Configuration()->write();
+
+            // Remove the NOT NULL from the Author tables
+            try {
+                $author = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_author`");
+
+                foreach ($author as $id) {
+                    $table = '`tbl_entries_data_' . $id . '`';
+
+                    Symphony::Database()->query(
+                        'ALTER TABLE ' . $table . ' CHANGE `author_id` `author_id` INT(11) UNSIGNED NULL'
+                    );
+                }
+            } catch (Exception $ex) {
+            }
+
+            Symphony::Configuration()->write();
         }
 
-        public static function postUpdateNotes()
-        {
-            return array(
-                __('Version %s introduces some improvements and fixes to Static XML Datasources. If you have any Static XML Datasources in your installation, please be sure to re-save them through the Data Source Editor to prevent unexpected results.', array('<code>2.2.1</code>'))
-            );
-        }
+        // Update the version information
+        return parent::upgrade();
     }
+
+    public static function postUpdateNotes()
+    {
+        return array(
+            __(
+                'Version %s introduces some improvements and fixes to Static XML Datasources. If you have any Static XML Datasources in your installation, please be sure to re-save them through the Data Source Editor to prevent unexpected results.',
+                array('<code>2.2.1</code>')
+            )
+        );
+    }
+}

--- a/install/migrations/2.2.2.php
+++ b/install/migrations/2.2.2.php
@@ -1,4 +1,9 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
+    use Exception;
 
     class migration_222 extends Migration
     {

--- a/install/migrations/2.2.2.php
+++ b/install/migrations/2.2.2.php
@@ -1,65 +1,71 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
-    use Exception;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
+use Exception;
 
-    class migration_222 extends Migration
+class migration_222 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.2.2';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.2.2/';
-        }
-
-        public static function upgrade()
-        {
-            // 2.2.2 Beta 1
-            if (version_compare(self::$existing_version, '2.2.2 Beta 1', '<=')) {
-                Symphony::Configuration()->set('version', '2.2.2 Beta 1', 'symphony');
-
-                // Rename old variations of the query_caching configuration setting
-                if (Symphony::Configuration()->get('disable_query_caching', 'database')) {
-                    $value = (Symphony::Configuration()->get('disable_query_caching', 'database') === "no") ? "on" : "off";
-
-                    Symphony::Configuration()->set('query_caching', $value, 'database');
-                    Symphony::Configuration()->remove('disable_query_caching', 'database');
-                }
-
-                // Add Session GC collection as a configuration parameter
-                Symphony::Configuration()->set('session_gc_divisor', '10', 'symphony');
-
-                // Save the manifest changes
-                Symphony::Configuration()->write();
-            }
-
-            // 2.2.2 Beta 2
-            if (version_compare(self::$existing_version, '2.2.2 Beta 2', '<=')) {
-                Symphony::Configuration()->set('version', '2.2.2 Beta 2', 'symphony');
-                try {
-                    // Change Textareas to be MEDIUMTEXT columns
-                    $textarea_tables = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_textarea`");
-
-                    foreach ($textarea_tables as $field) {
-                        Symphony::Database()->query(sprintf(
-                            "ALTER TABLE `tbl_entries_data_%d` CHANGE `value` `value` MEDIUMTEXT, CHANGE `value_formatted` `value_formatted` MEDIUMTEXT",
-                            $field
-                        ));
-                        Symphony::Database()->query(sprintf('OPTIMIZE TABLE `tbl_entries_data_%d`', $field));
-                    }
-                } catch (Exception $ex) {
-                }
-
-                // Save the manifest changes
-                Symphony::Configuration()->write();
-            }
-
-            // Update the version information
-            return parent::upgrade();
-        }
+        return '2.2.2';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.2.2/';
+    }
+
+    public static function upgrade()
+    {
+        // 2.2.2 Beta 1
+        if (version_compare(self::$existing_version, '2.2.2 Beta 1', '<=')) {
+            Symphony::Configuration()->set('version', '2.2.2 Beta 1', 'symphony');
+
+            // Rename old variations of the query_caching configuration setting
+            if (Symphony::Configuration()->get('disable_query_caching', 'database')) {
+                $value = (Symphony::Configuration()->get(
+                    'disable_query_caching',
+                    'database'
+                ) === "no") ? "on" : "off";
+
+                Symphony::Configuration()->set('query_caching', $value, 'database');
+                Symphony::Configuration()->remove('disable_query_caching', 'database');
+            }
+
+            // Add Session GC collection as a configuration parameter
+            Symphony::Configuration()->set('session_gc_divisor', '10', 'symphony');
+
+            // Save the manifest changes
+            Symphony::Configuration()->write();
+        }
+
+        // 2.2.2 Beta 2
+        if (version_compare(self::$existing_version, '2.2.2 Beta 2', '<=')) {
+            Symphony::Configuration()->set('version', '2.2.2 Beta 2', 'symphony');
+            try {
+                // Change Textareas to be MEDIUMTEXT columns
+                $textarea_tables = Symphony::Database()->fetchCol(
+                    "field_id",
+                    "SELECT `field_id` FROM `tbl_fields_textarea`"
+                );
+
+                foreach ($textarea_tables as $field) {
+                    Symphony::Database()->query(sprintf(
+                        "ALTER TABLE `tbl_entries_data_%d` CHANGE `value` `value` MEDIUMTEXT, CHANGE `value_formatted` `value_formatted` MEDIUMTEXT",
+                        $field
+                    ));
+                    Symphony::Database()->query(sprintf('OPTIMIZE TABLE `tbl_entries_data_%d`', $field));
+                }
+            } catch (Exception $ex) {
+            }
+
+            // Save the manifest changes
+            Symphony::Configuration()->write();
+        }
+
+        // Update the version information
+        return parent::upgrade();
+    }
+}

--- a/install/migrations/2.2.3.php
+++ b/install/migrations/2.2.3.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_223 extends Migration
     {

--- a/install/migrations/2.2.3.php
+++ b/install/migrations/2.2.3.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_223 extends Migration
+class migration_223 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.2.3';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.2.3/';
-        }
+        return '2.2.3';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.2.3/';
+    }
+}

--- a/install/migrations/2.2.4.php
+++ b/install/migrations/2.2.4.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_224 extends Migration
     {

--- a/install/migrations/2.2.4.php
+++ b/install/migrations/2.2.4.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_224 extends Migration
+class migration_224 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.2.4';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.2.4/';
-        }
+        return '2.2.4';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.2.4/';
+    }
+}

--- a/install/migrations/2.2.5.php
+++ b/install/migrations/2.2.5.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_225 extends Migration
+class migration_225 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.2.5';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.2.5/';
-        }
+        return '2.2.5';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.2.5/';
+    }
+}

--- a/install/migrations/2.2.5.php
+++ b/install/migrations/2.2.5.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_225 extends Migration
     {

--- a/install/migrations/2.3.0.php
+++ b/install/migrations/2.3.0.php
@@ -1,205 +1,218 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
-    use Exception;
-    use DatabaseException;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
+use Exception;
+use DatabaseException;
 
-    class migration_230 extends Migration
+class migration_230 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.3';
-        }
+        return '2.3';
+    }
 
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.3/';
-        }
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.3/';
+    }
 
-        public static function upgrade()
-        {
-            // 2.3dev
-            if (version_compare(self::$existing_version, '2.3dev', '<=')) {
-                Symphony::Configuration()->set('version', '2.3dev', 'symphony');
-                Symphony::Configuration()->set('useragent', 'Symphony/2.3dev', 'general');
+    public static function upgrade()
+    {
+        // 2.3dev
+        if (version_compare(self::$existing_version, '2.3dev', '<=')) {
+            Symphony::Configuration()->set('version', '2.3dev', 'symphony');
+            Symphony::Configuration()->set('useragent', 'Symphony/2.3dev', 'general');
 
-                // Add Publish Label to `tbl_fields`
-                if (!Symphony::Database()->tableContainsField('tbl_fields', 'publish_label')) {
-                    Symphony::Database()->query('ALTER TABLE `tbl_fields` ADD `publish_label` VARCHAR(255) DEFAULT NULL');
+            // Add Publish Label to `tbl_fields`
+            if (!Symphony::Database()->tableContainsField('tbl_fields', 'publish_label')) {
+                Symphony::Database()->query('ALTER TABLE `tbl_fields` ADD `publish_label` VARCHAR(255) DEFAULT NULL');
+            }
+
+            // Migrate any Checkbox's Long Description to Publish Label
+            try {
+                $checkboxes = Symphony::Database()->fetch("SELECT `field_id`, `description` FROM `tbl_fields_checkbox`");
+
+                foreach ($checkboxes as $field) {
+                    if (!isset($field['description'])) {
+                        continue;
+                    }
+
+                    Symphony::Database()->query(sprintf(
+                        "
+                        UPDATE `tbl_fields`
+                        SET `publish_label` = '%s'
+                        WHERE `id` = %d
+                        LIMIT 1;
+                        ",
+                        $field['description'],
+                        $field['field_id']
+                    ));
                 }
 
-                // Migrate any Checkbox's Long Description to Publish Label
-                try {
-                    $checkboxes = Symphony::Database()->fetch("SELECT `field_id`, `description` FROM `tbl_fields_checkbox`");
+                Symphony::Database()->query("ALTER TABLE `tbl_fields_checkbox` DROP `description`");
+            } catch (Exception $ex) {
+            }
 
-                    foreach ($checkboxes as $field) {
-                        if (!isset($field['description'])) {
+            // Removing unused settings
+            Symphony::Configuration()->remove('allow_page_subscription', 'symphony');
+            Symphony::Configuration()->remove('strict_error_handling', 'symphony');
+            Symphony::Configuration()->remove('character_set', 'database');
+            Symphony::Configuration()->remove('character_encoding', 'database');
+            Symphony::Configuration()->remove('runtime_character_set_alter', 'database');
+
+            if (Symphony::Configuration()->get('pagination_maximum_rows', 'symphony') === '17') {
+                Symphony::Configuration()->set('pagination_maximum_rows', '20', 'symphony');
+            }
+
+            Symphony::Configuration()->write();
+        }
+
+        // 2.3 Beta 1
+        if (version_compare(self::$existing_version, '2.3beta1', '<=')) {
+            Symphony::Configuration()->set('version', '2.3beta1', 'symphony');
+            Symphony::Configuration()->set('useragent', 'Symphony/2.3 Beta 1', 'general');
+
+            Symphony::Configuration()->write();
+        }
+
+        // 2.3 Beta 2
+        if (version_compare(self::$existing_version, '2.3beta2', '<=')) {
+            // Migrate Publish Labels (if created) to the Label field
+            // Then drop Publish Label, we're going to use element_name and label
+            // to take care of the same functionality!
+            try {
+                if (Symphony::Database()->tableContainsField('tbl_fields', 'publish_label')) {
+                    $fields = Symphony::Database()->fetch('SELECT `publish_label`, `label`, `id` FROM `tbl_fields`');
+
+                    foreach ($fields as $field) {
+                        if (!$field['publish_label']) {
                             continue;
                         }
 
-                        Symphony::Database()->query(sprintf("
+                        Symphony::Database()->query(sprintf(
+                            "
                             UPDATE `tbl_fields`
-                            SET `publish_label` = '%s'
+                            SET `label` = '%s'
                             WHERE `id` = %d
                             LIMIT 1;
                             ",
-                            $field['description'],
-                            $field['field_id']
+                            $field['publish_label'],
+                            $field['id']
                         ));
                     }
 
-                    Symphony::Database()->query("ALTER TABLE `tbl_fields_checkbox` DROP `description`");
-                } catch (Exception $ex) {
+                    Symphony::Database()->query("ALTER TABLE `tbl_fields` DROP `publish_label`");
                 }
-
-                // Removing unused settings
-                Symphony::Configuration()->remove('allow_page_subscription', 'symphony');
-                Symphony::Configuration()->remove('strict_error_handling', 'symphony');
-                Symphony::Configuration()->remove('character_set', 'database');
-                Symphony::Configuration()->remove('character_encoding', 'database');
-                Symphony::Configuration()->remove('runtime_character_set_alter', 'database');
-
-                if (Symphony::Configuration()->get('pagination_maximum_rows', 'symphony') === '17') {
-                    Symphony::Configuration()->set('pagination_maximum_rows', '20', 'symphony');
-                }
-
-                Symphony::Configuration()->write();
+            } catch (Exception $ex) {
+                Symphony::Log()->notice($ex->getMessage());
             }
 
-            // 2.3 Beta 1
-            if (version_compare(self::$existing_version, '2.3beta1', '<=')) {
-                Symphony::Configuration()->set('version', '2.3beta1', 'symphony');
-                Symphony::Configuration()->set('useragent', 'Symphony/2.3 Beta 1', 'general');
+            // Add uniqueness constraint for the Authors table. #937
+            try {
+                Symphony::Database()->query("ALTER TABLE `tbl_authors` ADD UNIQUE KEY `email` (`email`)");
+            } catch (DatabaseException $ex) {
+                // 1061 will be 'duplicate key', which is fine (means key was added earlier)
+                // 1062 means the key failed to apply, which is bad.
+                // @see http://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html
+                if ($ex->getDatabaseErrorCode() === 1062) {
+                    Symphony::Log()->error(
+                        __("You have multiple Authors with the same email address, which can cause issues with password retrieval. Please ensure all Authors have unique email addresses before updating. " . $ex->getMessage())
+                    );
 
-                Symphony::Configuration()->write();
-            }
-
-            // 2.3 Beta 2
-            if (version_compare(self::$existing_version, '2.3beta2', '<=')) {
-                // Migrate Publish Labels (if created) to the Label field
-                // Then drop Publish Label, we're going to use element_name and label
-                // to take care of the same functionality!
-                try {
-                    if (Symphony::Database()->tableContainsField('tbl_fields', 'publish_label')) {
-                        $fields = Symphony::Database()->fetch('SELECT `publish_label`, `label`, `id` FROM `tbl_fields`');
-
-                        foreach ($fields as $field) {
-                            if (!$field['publish_label']) {
-                                continue;
-                            }
-
-                            Symphony::Database()->query(sprintf("
-                                UPDATE `tbl_fields`
-                                SET `label` = '%s'
-                                WHERE `id` = %d
-                                LIMIT 1;
-                                ",
-                                $field['publish_label'],
-                                $field['id']
-                            ));
-                        }
-
-                        Symphony::Database()->query("ALTER TABLE `tbl_fields` DROP `publish_label`");
-                    }
-                } catch (Exception $ex) {
-                    Symphony::Log()->notice($ex->getMessage());
-                }
-
-                // Add uniqueness constraint for the Authors table. #937
-                try {
-                    Symphony::Database()->query("ALTER TABLE `tbl_authors` ADD UNIQUE KEY `email` (`email`)");
-                } catch (DatabaseException $ex) {
-                    // 1061 will be 'duplicate key', which is fine (means key was added earlier)
-                    // 1062 means the key failed to apply, which is bad.
-                    // @see http://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html
-                    if ($ex->getDatabaseErrorCode() === 1062) {
-                        Symphony::Log()->error(
-                            __("You have multiple Authors with the same email address, which can cause issues with password retrieval. Please ensure all Authors have unique email addresses before updating. " . $ex->getMessage())
-                        );
-
-                        return false;
-                    }
-                }
-
-                // Update the version information
-                Symphony::Configuration()->set('version', '2.3beta2', 'symphony');
-                Symphony::Configuration()->set('useragent', 'Symphony/2.3 Beta 2', 'general');
-
-                Symphony::Configuration()->write();
-            }
-
-            // 2.3 Beta 3
-            if (version_compare(self::$existing_version, '2.3beta3', '<=')) {
-                // Refresh indexes on existing Author field tables
-                $author_fields = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_author`");
-
-                foreach ($author_fields as $id) {
-                    $table = 'tbl_entries_data_' . $id;
-
-                    // MySQL doesn't support DROP IF EXISTS, so we'll try and catch.
-                    try {
-                        Symphony::Database()->query("ALTER TABLE `" . $table . "` DROP INDEX `entry_id`");
-                    } catch (Exception $ex) {
-                    }
-
-                    try {
-                        Symphony::Database()->query("CREATE UNIQUE INDEX `author` ON `" . $table . "` (`entry_id`, `author_id`)");
-                        Symphony::Database()->query("OPTIMIZE TABLE " . $table);
-                    } catch (Exception $ex) {
-                    }
-                }
-
-                // Move section sorting data from the database to the filesystem. #977
-                if (Symphony::Database()->tableContainsField('tbl_sections', 'entry_order')) {
-                    $sections = Symphony::Database()->fetch("SELECT `handle`, `entry_order`, `entry_order_direction` FROM `tbl_sections`");
-                    foreach ($sections as $s) {
-                        Symphony::Configuration()->set('section_' . $s['handle'] . '_sortby', $s['entry_order'], 'sorting');
-                        Symphony::Configuration()->set('section_' . $s['handle'] . '_order', $s['entry_order_direction'], 'sorting');
-                    }
-                }
-
-                // Drop `local`/`gmt` from Date fields, add `date` column. #693
-                $date_fields = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_date`");
-
-                foreach ($date_fields as $id) {
-                    $table = 'tbl_entries_data_' . $id;
-
-                    // Don't catch an Exception, we should halt updating if something goes wrong here
-                    // Add the new `date` column for Date fields
-                    if (!Symphony::Database()->tableContainsField($table, 'date')) {
-                        Symphony::Database()->query("ALTER TABLE `" . $table . "` ADD `date` DATETIME DEFAULT NULL");
-                        Symphony::Database()->query("CREATE INDEX `date` ON `" . $table . "` (`date`)");
-                    }
-
-                    if (Symphony::Database()->tableContainsField($table, 'date')) {
-                        // Populate new Date column
-                        if (Symphony::Database()->query("UPDATE `" . $table . "` SET date = CONVERT_TZ(SUBSTRING(value, 1, 19), SUBSTRING(value, -6), '+00:00')")) {
-                            // Drop the `local`/`gmt` columns from Date fields
-                            if (Symphony::Database()->tableContainsField($table, 'local')) {
-                                Symphony::Database()->query("ALTER TABLE `" . $table . "` DROP `local`;");
-                            }
-
-                            if (Symphony::Database()->tableContainsField($table, 'gmt')) {
-                                Symphony::Database()->query("ALTER TABLE `" . $table . "` DROP `gmt`;");
-                            }
-                        }
-                    }
-
-                    Symphony::Database()->query("OPTIMIZE TABLE " . $table);
+                    return false;
                 }
             }
 
             // Update the version information
-            return parent::upgrade();
+            Symphony::Configuration()->set('version', '2.3beta2', 'symphony');
+            Symphony::Configuration()->set('useragent', 'Symphony/2.3 Beta 2', 'general');
+
+            Symphony::Configuration()->write();
         }
 
-        public static function preUpdateNotes()
-        {
-            return array(
-                __("Symphony 2.3 is a major release that contains breaking changes from previous versions. It is highly recommended to review the releases notes and make a complete backup of your installation before updating as these changes may affect the functionality of your site."),
-                __("This release enforces that Authors must have unique email addresses. If multiple Authors have the same email address, this update will fail.")
+        // 2.3 Beta 3
+        if (version_compare(self::$existing_version, '2.3beta3', '<=')) {
+            // Refresh indexes on existing Author field tables
+            $author_fields = Symphony::Database()->fetchCol(
+                "field_id",
+                "SELECT `field_id` FROM `tbl_fields_author`"
             );
+
+            foreach ($author_fields as $id) {
+                $table = 'tbl_entries_data_' . $id;
+
+                // MySQL doesn't support DROP IF EXISTS, so we'll try and catch.
+                try {
+                    Symphony::Database()->query("ALTER TABLE `" . $table . "` DROP INDEX `entry_id`");
+                } catch (Exception $ex) {
+                }
+
+                try {
+                    Symphony::Database()->query("CREATE UNIQUE INDEX `author` ON `" . $table . "` (`entry_id`, `author_id`)");
+                    Symphony::Database()->query("OPTIMIZE TABLE " . $table);
+                } catch (Exception $ex) {
+                }
+            }
+
+            // Move section sorting data from the database to the filesystem. #977
+            if (Symphony::Database()->tableContainsField('tbl_sections', 'entry_order')) {
+                $sections = Symphony::Database()->fetch("SELECT `handle`, `entry_order`, `entry_order_direction` FROM `tbl_sections`");
+                foreach ($sections as $s) {
+                    Symphony::Configuration()->set(
+                        'section_' . $s['handle'] . '_sortby',
+                        $s['entry_order'],
+                        'sorting'
+                    );
+                    Symphony::Configuration()->set(
+                        'section_' . $s['handle'] . '_order',
+                        $s['entry_order_direction'],
+                        'sorting'
+                    );
+                }
+            }
+
+            // Drop `local`/`gmt` from Date fields, add `date` column. #693
+            $date_fields = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_date`");
+
+            foreach ($date_fields as $id) {
+                $table = 'tbl_entries_data_' . $id;
+
+                // Don't catch an Exception, we should halt updating if something goes wrong here
+                // Add the new `date` column for Date fields
+                if (!Symphony::Database()->tableContainsField($table, 'date')) {
+                    Symphony::Database()->query("ALTER TABLE `" . $table . "` ADD `date` DATETIME DEFAULT NULL");
+                    Symphony::Database()->query("CREATE INDEX `date` ON `" . $table . "` (`date`)");
+                }
+
+                if (Symphony::Database()->tableContainsField($table, 'date')) {
+                    // Populate new Date column
+                    if (Symphony::Database()->query("UPDATE `" . $table . "` SET date = CONVERT_TZ(SUBSTRING(value, 1, 19), SUBSTRING(value, -6), '+00:00')")) {
+                        // Drop the `local`/`gmt` columns from Date fields
+                        if (Symphony::Database()->tableContainsField($table, 'local')) {
+                            Symphony::Database()->query("ALTER TABLE `" . $table . "` DROP `local`;");
+                        }
+
+                        if (Symphony::Database()->tableContainsField($table, 'gmt')) {
+                            Symphony::Database()->query("ALTER TABLE `" . $table . "` DROP `gmt`;");
+                        }
+                    }
+                }
+
+                Symphony::Database()->query("OPTIMIZE TABLE " . $table);
+            }
         }
+
+        // Update the version information
+        return parent::upgrade();
     }
+
+    public static function preUpdateNotes()
+    {
+        return array(
+            __("Symphony 2.3 is a major release that contains breaking changes from previous versions. It is highly recommended to review the releases notes and make a complete backup of your installation before updating as these changes may affect the functionality of your site."),
+            __("This release enforces that Authors must have unique email addresses. If multiple Authors have the same email address, this update will fail.")
+        );
+    }
+}

--- a/install/migrations/2.3.0.php
+++ b/install/migrations/2.3.0.php
@@ -1,4 +1,10 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
+    use Exception;
+    use DatabaseException;
 
     class migration_230 extends Migration
     {

--- a/install/migrations/2.3.1.php
+++ b/install/migrations/2.3.1.php
@@ -1,4 +1,9 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
+    use Exception;
 
     class migration_231 extends Migration
     {

--- a/install/migrations/2.3.1.php
+++ b/install/migrations/2.3.1.php
@@ -1,87 +1,90 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
-    use Exception;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
+use Exception;
 
-    class migration_231 extends Migration
+class migration_231 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.3.1';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.3.1/';
-        }
-
-        public static function upgrade()
-        {
-            // 2.3.1dev
-            if (version_compare(self::$existing_version, '2.3.1dev', '<=')) {
-
-                // Remove unused setting from the Author field
-                $author_table = 'tbl_fields_author';
-                if (Symphony::Database()->tableContainsField($author_table, 'allow_author_change')) {
-                    Symphony::Database()->query("ALTER TABLE `$author_table` DROP `allow_author_change`;");
-                }
-
-                // Author Types [#1219]
-                if (!Symphony::Database()->tableContainsField($author_table, 'author_types')) {
-                    Symphony::Database()->query("ALTER TABLE `$author_table` ADD `author_types` VARCHAR(255) DEFAULT NULL;");
-                }
-
-                // Entries Modification Date [#983]
-                if (!Symphony::Database()->tableContainsField('tbl_entries', 'modification_date')) {
-                    Symphony::Database()->query("ALTER TABLE `tbl_entries` ADD `modification_date` DATETIME NOT NULL;");
-                    Symphony::Database()->query("ALTER TABLE `tbl_entries` ADD KEY `modification_date` (`modification_date`)");
-                    Symphony::Database()->query("UPDATE `tbl_entries` SET modification_date = creation_date;");
-                }
-
-                if (!Symphony::Database()->tableContainsField('tbl_entries', 'modification_date_gmt')) {
-                    Symphony::Database()->query("ALTER TABLE `tbl_entries` ADD `modification_date_gmt` DATETIME NOT NULL;");
-                    Symphony::Database()->query("ALTER TABLE `tbl_entries` ADD KEY `modification_date_gmt` (`modification_date_gmt`)");
-                    Symphony::Database()->query("UPDATE `tbl_entries` SET modification_date_gmt = creation_date_gmt;");
-                }
-
-                // Cleanup #977, remove `entry_order` & `entry_order_direction` from `tbl_sections`
-                if (Symphony::Database()->tableContainsField('tbl_sections', 'entry_order')) {
-                    Symphony::Database()->query("ALTER TABLE `tbl_sections` DROP `entry_order`;");
-                }
-
-                if (Symphony::Database()->tableContainsField('tbl_sections', 'entry_order_direction')) {
-                    Symphony::Database()->query("ALTER TABLE `tbl_sections` DROP `entry_order_direction`;");
-                }
-            }
-
-            if (version_compare(self::$existing_version, '2.3.1RC1', '<=')) {
-                // Add Security Rules from 2.2 to .htaccess
-                try {
-                    $htaccess = file_get_contents(DOCROOT . '/.htaccess');
-
-                    if ($htaccess !== false && preg_match('/### SECURITY - Protect crucial files/', $htaccess)) {
-                        $security = '
-            ### SECURITY - Protect crucial files
-            RewriteRule ^manifest/(.*)$ - [F]
-            RewriteRule ^workspace/(pages|utilities)/(.*)\.xsl$ - [F]
-            RewriteRule ^(.*)\.sql$ - [F]
-            RewriteRule (^|/)\. - [F]
-
-            ### DO NOT APPLY RULES WHEN REQUESTING "favicon.ico"';
-
-                        $htaccess = str_replace('### SECURITY - Protect crucial files.*### DO NOT APPLY RULES WHEN REQUESTING "favicon.ico"', $security, $htaccess);
-                        file_put_contents(DOCROOT . '/.htaccess', $htaccess);
-                    }
-                } catch (Exception $ex) {
-                }
-
-                // Increase length of password field to accomodate longer hashes
-                Symphony::Database()->query("ALTER TABLE `tbl_authors` CHANGE `password` `password` VARCHAR( 150 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL");
-            }
-
-            // Update the version information
-            return parent::upgrade();
-        }
+        return '2.3.1';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.3.1/';
+    }
+
+    public static function upgrade()
+    {
+        // 2.3.1dev
+        if (version_compare(self::$existing_version, '2.3.1dev', '<=')) {
+            // Remove unused setting from the Author field
+            $author_table = 'tbl_fields_author';
+            if (Symphony::Database()->tableContainsField($author_table, 'allow_author_change')) {
+                Symphony::Database()->query("ALTER TABLE `$author_table` DROP `allow_author_change`;");
+            }
+
+            // Author Types [#1219]
+            if (!Symphony::Database()->tableContainsField($author_table, 'author_types')) {
+                Symphony::Database()->query("ALTER TABLE `$author_table` ADD `author_types` VARCHAR(255) DEFAULT NULL;");
+            }
+
+            // Entries Modification Date [#983]
+            if (!Symphony::Database()->tableContainsField('tbl_entries', 'modification_date')) {
+                Symphony::Database()->query("ALTER TABLE `tbl_entries` ADD `modification_date` DATETIME NOT NULL;");
+                Symphony::Database()->query("ALTER TABLE `tbl_entries` ADD KEY `modification_date` (`modification_date`)");
+                Symphony::Database()->query("UPDATE `tbl_entries` SET modification_date = creation_date;");
+            }
+
+            if (!Symphony::Database()->tableContainsField('tbl_entries', 'modification_date_gmt')) {
+                Symphony::Database()->query("ALTER TABLE `tbl_entries` ADD `modification_date_gmt` DATETIME NOT NULL;");
+                Symphony::Database()->query("ALTER TABLE `tbl_entries` ADD KEY `modification_date_gmt` (`modification_date_gmt`)");
+                Symphony::Database()->query("UPDATE `tbl_entries` SET modification_date_gmt = creation_date_gmt;");
+            }
+
+            // Cleanup #977, remove `entry_order` & `entry_order_direction` from `tbl_sections`
+            if (Symphony::Database()->tableContainsField('tbl_sections', 'entry_order')) {
+                Symphony::Database()->query("ALTER TABLE `tbl_sections` DROP `entry_order`;");
+            }
+
+            if (Symphony::Database()->tableContainsField('tbl_sections', 'entry_order_direction')) {
+                Symphony::Database()->query("ALTER TABLE `tbl_sections` DROP `entry_order_direction`;");
+            }
+        }
+
+        if (version_compare(self::$existing_version, '2.3.1RC1', '<=')) {
+            // Add Security Rules from 2.2 to .htaccess
+            try {
+                $htaccess = file_get_contents(DOCROOT . '/.htaccess');
+
+                if ($htaccess !== false && preg_match('/### SECURITY - Protect crucial files/', $htaccess)) {
+                    $security = '
+        ### SECURITY - Protect crucial files
+        RewriteRule ^manifest/(.*)$ - [F]
+        RewriteRule ^workspace/(pages|utilities)/(.*)\.xsl$ - [F]
+        RewriteRule ^(.*)\.sql$ - [F]
+        RewriteRule (^|/)\. - [F]
+
+        ### DO NOT APPLY RULES WHEN REQUESTING "favicon.ico"';
+
+                    $htaccess = str_replace(
+                        '### SECURITY - Protect crucial files.*### DO NOT APPLY RULES WHEN REQUESTING "favicon.ico"',
+                        $security,
+                        $htaccess
+                    );
+                    file_put_contents(DOCROOT . '/.htaccess', $htaccess);
+                }
+            } catch (Exception $ex) {
+            }
+
+            // Increase length of password field to accomodate longer hashes
+            Symphony::Database()->query("ALTER TABLE `tbl_authors` CHANGE `password` `password` VARCHAR( 150 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL");
+        }
+
+        // Update the version information
+        return parent::upgrade();
+    }
+}

--- a/install/migrations/2.3.2.php
+++ b/install/migrations/2.3.2.php
@@ -1,49 +1,52 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
 
-    class migration_232 extends Migration
+class migration_232 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.3.2';
-        }
+        return '2.3.2';
+    }
 
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.3.2/';
-        }
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.3.2/';
+    }
 
-        public static function upgrade()
-        {
-            //  Update DB for the new Mime-type length. #1534
-            if (version_compare(self::$existing_version, '2.3.2beta1', '<=')) {
-                $upload_entry_tables = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_upload`");
+    public static function upgrade()
+    {
+        //  Update DB for the new Mime-type length. #1534
+        if (version_compare(self::$existing_version, '2.3.2beta1', '<=')) {
+            $upload_entry_tables = Symphony::Database()->fetchCol(
+                "field_id",
+                "SELECT `field_id` FROM `tbl_fields_upload`"
+            );
 
-                if (is_array($upload_entry_tables) && !empty($upload_entry_tables)) {
-                    foreach ($upload_entry_tables as $field) {
-                        Symphony::Database()->query(sprintf(
-                            "ALTER TABLE `tbl_entries_data_%d` CHANGE `mimetype` `mimetype` varchar(100) DEFAULT NULL",
-                            $field
-                        ));
-                    }
+            if (is_array($upload_entry_tables) && !empty($upload_entry_tables)) {
+                foreach ($upload_entry_tables as $field) {
+                    Symphony::Database()->query(sprintf(
+                        "ALTER TABLE `tbl_entries_data_%d` CHANGE `mimetype` `mimetype` VARCHAR(100) DEFAULT NULL",
+                        $field
+                    ));
                 }
             }
-
-            // Reapply increase length of password field to accomodate longer hashes
-            // fix as it looks like we created an error in the 2.3.1 migration. RE #1648
-            Symphony::Database()->query("ALTER TABLE `tbl_authors` CHANGE `password` `password` VARCHAR( 150 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL");
-
-            // Update the version information
-            return parent::upgrade();
         }
 
-        public static function preUpdateNotes()
-        {
-            return array(
-                __("This release fixes a bug with the 'Redirect to 404 page when no results are found' setting on the Sections Datasource. Unfortunately you will need to resave your datasources to activate this fix.")
-            );
-        }
+        // Reapply increase length of password field to accomodate longer hashes
+        // fix as it looks like we created an error in the 2.3.1 migration. RE #1648
+        Symphony::Database()->query("ALTER TABLE `tbl_authors` CHANGE `password` `password` VARCHAR( 150 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL");
+
+        // Update the version information
+        return parent::upgrade();
     }
+
+    public static function preUpdateNotes()
+    {
+        return array(
+            __("This release fixes a bug with the 'Redirect to 404 page when no results are found' setting on the Sections Datasource. Unfortunately you will need to resave your datasources to activate this fix.")
+        );
+    }
+}

--- a/install/migrations/2.3.2.php
+++ b/install/migrations/2.3.2.php
@@ -1,4 +1,8 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
 
     class migration_232 extends Migration
     {

--- a/install/migrations/2.3.3.php
+++ b/install/migrations/2.3.3.php
@@ -1,57 +1,60 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
 
-    class migration_233 extends Migration
+class migration_233 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.3.3';
-        }
+        return '2.3.3';
+    }
 
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.3.3/';
-        }
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.3.3/';
+    }
 
-        public static function upgrade()
-        {
-            if (version_compare(self::$existing_version, '2.3.3beta1', '<=')) {
-                // Update DB for the new author role #1692
-                Symphony::Database()->query(
-                    "ALTER TABLE `tbl_authors` CHANGE `user_type` `user_type` enum('author', 'manager', 'developer') DEFAULT 'author'"
-                );
+    public static function upgrade()
+    {
+        if (version_compare(self::$existing_version, '2.3.3beta1', '<=')) {
+            // Update DB for the new author role #1692
+            Symphony::Database()->query(
+                "ALTER TABLE `tbl_authors` CHANGE `user_type` `user_type` ENUM('author', 'manager', 'developer') DEFAULT 'author'"
+            );
 
-                // Remove directory from the upload fields, #1719
-                $upload_tables = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_upload`");
+            // Remove directory from the upload fields, #1719
+            $upload_tables = Symphony::Database()->fetchCol(
+                "field_id",
+                "SELECT `field_id` FROM `tbl_fields_upload`"
+            );
 
-                if (is_array($upload_tables) && !empty($upload_tables)) {
-                    foreach ($upload_tables as $field) {
-                        Symphony::Database()->query(sprintf(
-                        "UPDATE tbl_entries_data_%d SET file = substring_index(file, '/', -1)",
+            if (is_array($upload_tables) && !empty($upload_tables)) {
+                foreach ($upload_tables as $field) {
+                    Symphony::Database()->query(sprintf(
+                        "UPDATE tbl_entries_data_%d SET FILE = substring_index(FILE, '/', -1)",
                         $field
                     ));
-                    }
                 }
             }
+        }
 
-            if (version_compare(self::$existing_version, '2.3.3beta2', '<=')) {
-                // Update rows for associations
-                if (!Symphony::Configuration()->get('association_maximum_rows', 'symphony')) {
-                    Symphony::Configuration()->set('association_maximum_rows', '5', 'symphony');
-                }
+        if (version_compare(self::$existing_version, '2.3.3beta2', '<=')) {
+            // Update rows for associations
+            if (!Symphony::Configuration()->get('association_maximum_rows', 'symphony')) {
+                Symphony::Configuration()->set('association_maximum_rows', '5', 'symphony');
             }
-
-            // Update the version information
-            return parent::upgrade();
         }
 
-        public static function preUpdateNotes()
-        {
-            return array(
-                __("On update, all files paths will be removed from the core Upload field entry tables. If you are using an Upload field extension, ensure that the extension is compatible with this release before continuing.")
-            );
-        }
+        // Update the version information
+        return parent::upgrade();
     }
+
+    public static function preUpdateNotes()
+    {
+        return array(
+            __("On update, all files paths will be removed from the core Upload field entry tables. If you are using an Upload field extension, ensure that the extension is compatible with this release before continuing.")
+        );
+    }
+}

--- a/install/migrations/2.3.3.php
+++ b/install/migrations/2.3.3.php
@@ -1,4 +1,8 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
 
     class migration_233 extends Migration
     {

--- a/install/migrations/2.3.4.php
+++ b/install/migrations/2.3.4.php
@@ -1,59 +1,59 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
-    use Exception;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
+use Exception;
 
-    class migration_234 extends Migration
+class migration_234 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.3.4';
-        }
+        return '2.3.4';
+    }
 
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.3.4/';
-        }
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.3.4/';
+    }
 
-        public static function upgrade()
-        {
-            if (version_compare(self::$existing_version, '2.3.4beta1', '<=')) {
-                // Detect mod_rewrite #1808
-                try {
-                    $htaccess = file_get_contents(DOCROOT . '/.htaccess');
+    public static function upgrade()
+    {
+        if (version_compare(self::$existing_version, '2.3.4beta1', '<=')) {
+            // Detect mod_rewrite #1808
+            try {
+                $htaccess = file_get_contents(DOCROOT . '/.htaccess');
 
-                    if ($htaccess !== false && !preg_match('/SetEnv HTTP_MOD_REWRITE No/', $htaccess)) {
-                        $rewrite = '
+                if ($htaccess !== false && !preg_match('/SetEnv HTTP_MOD_REWRITE No/', $htaccess)) {
+                    $rewrite = '
 <IfModule !mod_rewrite.c>
     SetEnv HTTP_MOD_REWRITE No
 </IfModule>
 
 <IfModule mod_rewrite.c>';
 
-                        $htaccess = str_replace('<IfModule mod_rewrite.c>', $rewrite, $htaccess);
-                        file_put_contents(DOCROOT . '/.htaccess', $htaccess);
-                    }
-                } catch (Exception $ex) {
+                    $htaccess = str_replace('<IfModule mod_rewrite.c>', $rewrite, $htaccess);
+                    file_put_contents(DOCROOT . '/.htaccess', $htaccess);
                 }
-
-                // Extend token field to enable more secure tokens
-                try {
-                    Symphony::Database()->query('ALTER TABLE `tbl_forgotpass` CHANGE `token` `token` VARCHAR(16);');
-                } catch (Exception $ex) {
-                }
+            } catch (Exception $ex) {
             }
 
-            if (version_compare(self::$existing_version, '2.3.4beta2', '<=')) {
-                // Extend session_id field for default Suhosin installs
-                try {
-                    Symphony::Database()->query('ALTER TABLE `tbl_sessions` CHANGE `session` `session` VARCHAR(128);');
-                } catch (Exception $ex) {
-                }
+            // Extend token field to enable more secure tokens
+            try {
+                Symphony::Database()->query('ALTER TABLE `tbl_forgotpass` CHANGE `token` `token` VARCHAR(16);');
+            } catch (Exception $ex) {
             }
-
-            // Update the version information
-            return parent::upgrade();
         }
+
+        if (version_compare(self::$existing_version, '2.3.4beta2', '<=')) {
+            // Extend session_id field for default Suhosin installs
+            try {
+                Symphony::Database()->query('ALTER TABLE `tbl_sessions` CHANGE `session` `session` VARCHAR(128);');
+            } catch (Exception $ex) {
+            }
+        }
+
+        // Update the version information
+        return parent::upgrade();
     }
+}

--- a/install/migrations/2.3.4.php
+++ b/install/migrations/2.3.4.php
@@ -1,4 +1,9 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
+    use Exception;
 
     class migration_234 extends Migration
     {

--- a/install/migrations/2.3.5.php
+++ b/install/migrations/2.3.5.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_235 extends Migration
     {

--- a/install/migrations/2.3.5.php
+++ b/install/migrations/2.3.5.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_235 extends Migration
+class migration_235 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.3.5';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.3.5/';
-        }
+        return '2.3.5';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.3.5/';
+    }
+}

--- a/install/migrations/2.3.6.php
+++ b/install/migrations/2.3.6.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_236 extends Migration
     {

--- a/install/migrations/2.3.6.php
+++ b/install/migrations/2.3.6.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_236 extends Migration
+class migration_236 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.3.6';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.3.6/';
-        }
+        return '2.3.6';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.3.6/';
+    }
+}

--- a/install/migrations/2.4.0.php
+++ b/install/migrations/2.4.0.php
@@ -1,4 +1,9 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
+    use Exception;
 
     class migration_240 extends Migration
     {

--- a/install/migrations/2.4.0.php
+++ b/install/migrations/2.4.0.php
@@ -1,119 +1,128 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
-    use Exception;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
+use Exception;
 
-    class migration_240 extends Migration
+class migration_240 extends Migration
+{
+    public static $publish_filtering_disabled = false;
+
+    public static function getVersion()
     {
-        public static $publish_filtering_disabled = false;
+        return '2.4';
+    }
 
-        public static function getVersion()
-        {
-            return '2.4';
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.4/';
+    }
+
+    public static function upgrade()
+    {
+        // [#702] Update to include Admin Path configuration
+        if (version_compare(self::$existing_version, '2.4beta2', '<=')) {
+            // Add missing config value for index view string length
+            Symphony::Configuration()->set('cell_truncation_length', '75', 'symphony');
+            // Add admin-path to configuration
+            Symphony::Configuration()->set('admin-path', 'symphony', 'symphony');
         }
 
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.4/';
-        }
+        // [#1626] Update all tables to be UTF-8 encoding/collation
+        // @link https://gist.github.com/michael-e/5789168
+        $tables = Symphony::Database()->fetch("SHOW TABLES");
+        if (is_array($tables) && !empty($tables)) {
+            foreach ($tables as $table) {
+                $table = current($table);
 
-        public static function upgrade()
-        {
-            // [#702] Update to include Admin Path configuration
-            if (version_compare(self::$existing_version, '2.4beta2', '<=')) {
-                // Add missing config value for index view string length
-                Symphony::Configuration()->set('cell_truncation_length', '75', 'symphony');
-                // Add admin-path to configuration
-                Symphony::Configuration()->set('admin-path', 'symphony', 'symphony');
-            }
-
-            // [#1626] Update all tables to be UTF-8 encoding/collation
-            // @link https://gist.github.com/michael-e/5789168
-            $tables = Symphony::Database()->fetch("SHOW TABLES");
-            if (is_array($tables) && !empty($tables)) {
-                foreach ($tables as $table) {
-                    $table = current($table);
-
-                    // If it's not a Symphony table, ignore it
-                    if (!preg_match('/^' . Symphony::Database()->getPrefix() . '/', $table)) {
-                        continue;
-                    }
-
-                    Symphony::Database()->query(sprintf(
-                        "ALTER TABLE `%s` CHARACTER SET utf8 COLLATE utf8_unicode_ci",
-                        $table
-                    ));
-                    Symphony::Database()->query(sprintf(
-                        "ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci",
-                        $table
-                    ));
+                // If it's not a Symphony table, ignore it
+                if (!preg_match('/^' . Symphony::Database()->getPrefix() . '/', $table)) {
+                    continue;
                 }
-            }
 
-            // [#1420] Change date field to be a varchar instead of an ENUM to support prepopulation
-            try {
-                Symphony::Database()->query('
-                    ALTER TABLE `tbl_fields_date`
-                    CHANGE `pre_populate` `pre_populate` varchar(80) COLLATE utf8_unicode_ci DEFAULT NULL;
-                ');
-            } catch (Exception $ex) {
+                Symphony::Database()->query(sprintf(
+                    "ALTER TABLE `%s` CHARACTER SET utf8 COLLATE utf8_unicode_ci",
+                    $table
+                ));
+                Symphony::Database()->query(sprintf(
+                    "ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci",
+                    $table
+                ));
             }
-
-            // [#1997] Add filtering column to the Sections table
-            if (!Symphony::Database()->tableContainsField('tbl_sections', 'filter')) {
-                Symphony::Database()->query("
-                    ALTER TABLE `tbl_sections`
-                    ADD `filter` enum('yes','no') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'yes';
-                ");
-            }
-
-            $installed_extensions = Symphony::ExtensionManager()->listInstalledHandles();
-            if (in_array('publishfiltering', $installed_extensions)) {
-                Symphony::ExtensionManager()->uninstall('publishfiltering');
-                self::$publish_filtering_disabled = true;
-            }
-
-            // [#1874] XSRF/CRSF options
-            if (version_compare(self::$existing_version, '2.4beta3', '<=')) {
-                // How long should a XSRF token be valid
-                Symphony::Configuration()->set('token_lifetime', '15 minutes', 'symphony');
-                // Should the token be removed as soon as it has been used?
-                Symphony::Configuration()->set('invalidate_tokens_on_request', false, 'symphony');
-            }
-
-            // [#1874] XSRF/CRSF options
-            if (version_compare(self::$existing_version, '2.4RC1', '<=')) {
-                // On update, disable XSRF for compatibility purposes
-                Symphony::Configuration()->set('enable_xsrf', 'no', 'symphony');
-            }
-
-            // Update the version information
-            return parent::upgrade();
         }
 
-        public static function preUpdateNotes()
-        {
-            return array(
-                __("Symphony 2.4 is a major release that contains breaking changes from previous versions. It is highly recommended to review the releases notes and make a complete backup of your installation before updating as these changes may affect the functionality of your site."),
-                __("This release will automatically convert all existing Symphony database tables to %s.", array("<code>utf8_unicode_ci</code>")),
-                __("CRSF has been implemented in this release and is turned off by default. To enable for the backend, change %s from %s to %s in your configuration. To enable for the frontend, update the XSS Filter extension and follow the README.", array('<code>enable_xsrf</code>', '<code>no</code>', '<code>yes</code>'))
-            );
+        // [#1420] Change date field to be a varchar instead of an ENUM to support prepopulation
+        try {
+            Symphony::Database()->query('
+                ALTER TABLE `tbl_fields_date`
+                CHANGE `pre_populate` `pre_populate` VARCHAR(80) COLLATE utf8_unicode_ci DEFAULT NULL;
+            ');
+        } catch (Exception $ex) {
         }
 
-        public static function postUpdateNotes()
-        {
-            $notes = array();
+        // [#1997] Add filtering column to the Sections table
+        if (!Symphony::Database()->tableContainsField('tbl_sections', 'filter')) {
+            Symphony::Database()->query("
+                ALTER TABLE `tbl_sections`
+                ADD `filter` ENUM('yes','no') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'yes';
+            ");
+        }
 
-            if (self::$publish_filtering_disabled) {
-                $notes[] = __("As Symphony 2.4 adds the Publish Filtering extension into the core, the standalone extension has been uninstalled. You can remove it from your installation at any time.");
-            }
+        $installed_extensions = Symphony::ExtensionManager()->listInstalledHandles();
+        if (in_array('publishfiltering', $installed_extensions)) {
+            Symphony::ExtensionManager()->uninstall('publishfiltering');
+            self::$publish_filtering_disabled = true;
+        }
 
-            $notes[] = __("The Dynamic XML Datasource has been deprecated from the core in favour of the %s extension. You will no longer be able to create new Dynamic XML Data Sources from the Symphony Data Source editor. Existing Dynamic XML Data Sources can be edited and will continue to function until Symphony 2.7.0.", array(
+        // [#1874] XSRF/CRSF options
+        if (version_compare(self::$existing_version, '2.4beta3', '<=')) {
+            // How long should a XSRF token be valid
+            Symphony::Configuration()->set('token_lifetime', '15 minutes', 'symphony');
+            // Should the token be removed as soon as it has been used?
+            Symphony::Configuration()->set('invalidate_tokens_on_request', false, 'symphony');
+        }
+
+        // [#1874] XSRF/CRSF options
+        if (version_compare(self::$existing_version, '2.4RC1', '<=')) {
+            // On update, disable XSRF for compatibility purposes
+            Symphony::Configuration()->set('enable_xsrf', 'no', 'symphony');
+        }
+
+        // Update the version information
+        return parent::upgrade();
+    }
+
+    public static function preUpdateNotes()
+    {
+        return array(
+            __("Symphony 2.4 is a major release that contains breaking changes from previous versions. It is highly recommended to review the releases notes and make a complete backup of your installation before updating as these changes may affect the functionality of your site."),
+            __(
+                "This release will automatically convert all existing Symphony database tables to %s.",
+                array("<code>utf8_unicode_ci</code>")
+            ),
+            __(
+                "CRSF has been implemented in this release and is turned off by default. To enable for the backend, change %s from %s to %s in your configuration. To enable for the frontend, update the XSS Filter extension and follow the README.",
+                array('<code>enable_xsrf</code>', '<code>no</code>', '<code>yes</code>')
+            )
+        );
+    }
+
+    public static function postUpdateNotes()
+    {
+        $notes = array();
+
+        if (self::$publish_filtering_disabled) {
+            $notes[] = __("As Symphony 2.4 adds the Publish Filtering extension into the core, the standalone extension has been uninstalled. You can remove it from your installation at any time.");
+        }
+
+        $notes[] = __(
+            "The Dynamic XML Datasource has been deprecated from the core in favour of the %s extension. You will no longer be able to create new Dynamic XML Data Sources from the Symphony Data Source editor. Existing Dynamic XML Data Sources can be edited and will continue to function until Symphony 2.7.0.",
+            array(
                 "<a href='http://symphonyextensions.com/extensions/remote_datasource/'>Remote Datasource</a>"
-            ));
+            )
+        );
 
             return $notes;
-        }
     }
+}

--- a/install/migrations/2.5.0.php
+++ b/install/migrations/2.5.0.php
@@ -1,48 +1,48 @@
 <?php
 
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
-    use Exception;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
+use Exception;
 
-    class migration_250 extends Migration
+class migration_250 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.5.0';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.5/';
-        }
-
-        public static function upgrade()
-        {
-            // Add association interfaces
-            try {
-                Symphony::Database()->query('
-                    ALTER TABLE `tbl_sections_association`
-                    ADD `interface` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
-                    ADD `editor` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL;
-                ');
-            } catch (Exception $ex) {
-            }
-
-            // Remove show_association #2082
-            try {
-                Symphony::Database()->query('
-                    ALTER TABLE `tbl_fields_select` DROP COLUMN show_association;
-                ');
-            } catch (Exception $ex) {
-            }
-
-            // Remove XSRF configuration options #2118
-            Symphony::Configuration()->remove('token_lifetime', 'symphony');
-            Symphony::Configuration()->remove('invalidate_tokens_on_request', 'symphony');
-
-            // Update the version information
-            return parent::upgrade();
-        }
+        return '2.5.0';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.5/';
+    }
+
+    public static function upgrade()
+    {
+        // Add association interfaces
+        try {
+            Symphony::Database()->query('
+                ALTER TABLE `tbl_sections_association`
+                ADD `interface` VARCHAR(100) COLLATE utf8_unicode_ci DEFAULT NULL,
+                ADD `editor` VARCHAR(100) COLLATE utf8_unicode_ci DEFAULT NULL;
+            ');
+        } catch (Exception $ex) {
+        }
+
+        // Remove show_association #2082
+        try {
+            Symphony::Database()->query('
+                ALTER TABLE `tbl_fields_select` DROP COLUMN show_association;
+            ');
+        } catch (Exception $ex) {
+        }
+
+        // Remove XSRF configuration options #2118
+        Symphony::Configuration()->remove('token_lifetime', 'symphony');
+        Symphony::Configuration()->remove('invalidate_tokens_on_request', 'symphony');
+
+        // Update the version information
+        return parent::upgrade();
+    }
+}

--- a/install/migrations/2.5.0.php
+++ b/install/migrations/2.5.0.php
@@ -1,5 +1,11 @@
 <?php
 
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
+    use Exception;
+
     class migration_250 extends Migration
     {
         public static function getVersion()

--- a/install/migrations/2.5.1.php
+++ b/install/migrations/2.5.1.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_251 extends Migration
+class migration_251 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.5.1';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.5.1/';
-        }
+        return '2.5.1';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.5.1/';
+    }
+}

--- a/install/migrations/2.5.1.php
+++ b/install/migrations/2.5.1.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_251 extends Migration
     {

--- a/install/migrations/2.5.2.php
+++ b/install/migrations/2.5.2.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_252 extends Migration
+class migration_252 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.5.2';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.5.2/';
-        }
+        return '2.5.2';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.5.2/';
+    }
+}

--- a/install/migrations/2.5.2.php
+++ b/install/migrations/2.5.2.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_252 extends Migration
     {

--- a/install/migrations/2.5.3.php
+++ b/install/migrations/2.5.3.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_253 extends Migration
     {

--- a/install/migrations/2.5.3.php
+++ b/install/migrations/2.5.3.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_253 extends Migration
+class migration_253 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.5.3';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.5.3/';
-        }
+        return '2.5.3';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.5.3/';
+    }
+}

--- a/install/migrations/2.6.0.php
+++ b/install/migrations/2.6.0.php
@@ -1,52 +1,52 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
-    use Exception;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
+use Exception;
 
-    class migration_260 extends Migration
+class migration_260 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.6.0';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.6.0/';
-        }
-
-        public static function upgrade()
-        {
-            // Add date field options
-            try {
-                Symphony::Database()->query('
-                    ALTER TABLE `tbl_fields_date`
-                    ADD `calendar` enum("yes","no") COLLATE utf8_unicode_ci NOT NULL DEFAULT "no",
-                    ADD `time` enum("yes","no") COLLATE utf8_unicode_ci NOT NULL DEFAULT "yes";
-                ');
-            } catch (Exception $ex) {
-            }
-
-            // Add namespace field to the cache table. RE: #2162
-            try {
-                Symphony::Database()->query('
-                    ALTER TABLE `tbl_cache` ADD `namespace` VARCHAR(255) COLLATE utf8_unicode_ci;
-                ');
-            } catch (Exception $ex) {
-            }
-
-            // Add UNIQUE key constraint to the `hash` RE: #2163
-            try {
-                Symphony::Database()->import('
-                    ALTER TABLE `tbl_cache` DROP INDEX `hash`;
-                    ALTER TABLE `tbl_cache` ADD UNIQUE INDEX `hash` (`hash`)
-                ');
-            } catch (Exception $ex) {
-            }
-
-            // Update the version information
-            return parent::upgrade();
-        }
+        return '2.6.0';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.6.0/';
+    }
+
+    public static function upgrade()
+    {
+        // Add date field options
+        try {
+            Symphony::Database()->query('
+                ALTER TABLE `tbl_fields_date`
+                ADD `calendar` ENUM("yes","no") COLLATE utf8_unicode_ci NOT NULL DEFAULT "no",
+                ADD `time` ENUM("yes","no") COLLATE utf8_unicode_ci NOT NULL DEFAULT "yes";
+            ');
+        } catch (Exception $ex) {
+        }
+
+        // Add namespace field to the cache table. RE: #2162
+        try {
+            Symphony::Database()->query('
+                ALTER TABLE `tbl_cache` ADD `namespace` VARCHAR(255) COLLATE utf8_unicode_ci;
+            ');
+        } catch (Exception $ex) {
+        }
+
+        // Add UNIQUE key constraint to the `hash` RE: #2163
+        try {
+            Symphony::Database()->import('
+                ALTER TABLE `tbl_cache` DROP INDEX `hash`;
+                ALTER TABLE `tbl_cache` ADD UNIQUE INDEX `hash` (`hash`)
+            ');
+        } catch (Exception $ex) {
+        }
+
+        // Update the version information
+        return parent::upgrade();
+    }
+}

--- a/install/migrations/2.6.0.php
+++ b/install/migrations/2.6.0.php
@@ -1,4 +1,9 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
+    use Exception;
 
     class migration_260 extends Migration
     {

--- a/install/migrations/2.6.1.php
+++ b/install/migrations/2.6.1.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_261 extends Migration
+class migration_261 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.6.1';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.6.1/';
-        }
+        return '2.6.1';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.6.1/';
+    }
+}

--- a/install/migrations/2.6.1.php
+++ b/install/migrations/2.6.1.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_261 extends Migration
     {

--- a/install/migrations/2.6.2.php
+++ b/install/migrations/2.6.2.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_262 extends Migration
     {

--- a/install/migrations/2.6.2.php
+++ b/install/migrations/2.6.2.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_262 extends Migration
+class migration_262 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.6.2';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.6.2/';
-        }
+        return '2.6.2';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.6.2/';
+    }
+}

--- a/install/migrations/2.6.3.php
+++ b/install/migrations/2.6.3.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_263 extends Migration
+class migration_263 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.6.3';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.6.3/';
-        }
+        return '2.6.3';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.6.3/';
+    }
+}

--- a/install/migrations/2.6.3.php
+++ b/install/migrations/2.6.3.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_263 extends Migration
     {

--- a/install/migrations/2.6.4.php
+++ b/install/migrations/2.6.4.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_264 extends Migration
+class migration_264 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.6.4';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.6.4/';
-        }
+        return '2.6.4';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.6.4/';
+    }
+}

--- a/install/migrations/2.6.4.php
+++ b/install/migrations/2.6.4.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_264 extends Migration
     {

--- a/install/migrations/2.6.5.php
+++ b/install/migrations/2.6.5.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_265 extends Migration
     {

--- a/install/migrations/2.6.5.php
+++ b/install/migrations/2.6.5.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_265 extends Migration
+class migration_265 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.6.5';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.6.5/';
-        }
+        return '2.6.5';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.6.5/';
+    }
+}

--- a/install/migrations/2.6.6.php
+++ b/install/migrations/2.6.6.php
@@ -1,30 +1,30 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
 
-    class migration_266 extends Migration
+class migration_266 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.6.6';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.6.6/';
-        }
-
-        public static function upgrade()
-        {
-            // Add the upload blacklist (see c763e6a)
-            $blacklist = Symphony::Configuration()->get('upload_blacklist', 'admin');
-            if (empty($blacklist)) {
-                Symphony::Configuration()->set('upload_blacklist', '/\.(?:php[34567s]?|phtml)$/i', 'admin');
-            }
-
-            // Update the version information
-            return parent::upgrade();
-        }
+        return '2.6.6';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.6.6/';
+    }
+
+    public static function upgrade()
+    {
+        // Add the upload blacklist (see c763e6a)
+        $blacklist = Symphony::Configuration()->get('upload_blacklist', 'admin');
+        if (empty($blacklist)) {
+            Symphony::Configuration()->set('upload_blacklist', '/\.(?:php[34567s]?|phtml)$/i', 'admin');
+        }
+
+        // Update the version information
+        return parent::upgrade();
+    }
+}

--- a/install/migrations/2.6.6.php
+++ b/install/migrations/2.6.6.php
@@ -1,4 +1,8 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
 
     class migration_266 extends Migration
     {

--- a/install/migrations/2.6.7.php
+++ b/install/migrations/2.6.7.php
@@ -1,17 +1,17 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
+use SymphonyCms\Installer\Lib\Migration;
 
-    class migration_267 extends Migration
+class migration_267 extends Migration
+{
+    public static function getVersion()
     {
-        public static function getVersion()
-        {
-            return '2.6.7';
-        }
-
-        public static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/2.6.7/';
-        }
+        return '2.6.7';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/2.6.7/';
+    }
+}

--- a/install/migrations/2.6.7.php
+++ b/install/migrations/2.6.7.php
@@ -1,4 +1,7 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
 
     class migration_267 extends Migration
     {

--- a/install/migrations/3.0.0.php
+++ b/install/migrations/3.0.0.php
@@ -1,49 +1,46 @@
 <?php
-    namespace SymphonyCms\Installer\Migrations;
+namespace SymphonyCms\Installer\Migrations;
 
-    use SymphonyCms\Installer\Lib\Migration;
-    use Symphony;
-    use Exception;
+use SymphonyCms\Installer\Lib\Migration;
+use Symphony;
+use Exception;
 
-    Class migration_300 extends Migration
+class migration_300 extends Migration
+{
+    public static function getVersion()
     {
-
-        static function getVersion()
-        {
-            return '3.0.0-alpha.1';
-        }
-
-        static function getReleaseNotes()
-        {
-            return 'http://getsymphony.com/download/releases/version/3.0.0/';
-        }
-
-        static function upgrade()
-        {
-            // Add the delegate order field, RE: #2354
-            try {
-                Symphony::Database()->query("
-                    ALTER TABLE `tbl_extensions_delegates`
-                    ADD `order` int(11) SIGNED NOT NULL DEFAULT '0',
-                ");
-            }
-            catch (Exception $ex) {
-
-            }
-
-            // Add in new Session configuration options, RE: #2135
-            Symphony::Configuration()->setArray(array(
-                'session' => array(
-                    'admin_session_name' => 'symphony_admin',
-                    'public_session_name' => 'symphony_public',
-                    'admin_session_expires' => '2 weeks',
-                    'public_session_expires' => '2 weeks',
-                    'session_gc_probability' => '1',
-                    'session_gc_divisor' => Symphony::Configuration()->get('session_gc_divisor', 'symphony')
-                )
-            ));
-
-            // Update the version information
-            return parent::upgrade();
-        }
+        return '3.0.0-alpha.1';
     }
+
+    public static function getReleaseNotes()
+    {
+        return 'http://getsymphony.com/download/releases/version/3.0.0/';
+    }
+
+    public static function upgrade()
+    {
+        // Add the delegate order field, RE: #2354
+        try {
+            Symphony::Database()->query("
+                ALTER TABLE `tbl_extensions_delegates`
+                ADD `order` INT(11) SIGNED NOT NULL DEFAULT '0',
+            ");
+        } catch (Exception $ex) {
+        }
+
+        // Add in new Session configuration options, RE: #2135
+        Symphony::Configuration()->setArray(array(
+            'session' => array(
+                'admin_session_name' => 'symphony_admin',
+                'public_session_name' => 'symphony_public',
+                'admin_session_expires' => '2 weeks',
+                'public_session_expires' => '2 weeks',
+                'session_gc_probability' => '1',
+                'session_gc_divisor' => Symphony::Configuration()->get('session_gc_divisor', 'symphony')
+            )
+        ));
+
+        // Update the version information
+        return parent::upgrade();
+    }
+}

--- a/install/migrations/3.0.0.php
+++ b/install/migrations/3.0.0.php
@@ -1,4 +1,9 @@
 <?php
+    namespace SymphonyCms\Installer\Migrations;
+
+    use SymphonyCms\Installer\Lib\Migration;
+    use Symphony;
+    use Exception;
 
     Class migration_300 extends Migration
     {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="Symphony CMS">
+    <config name="ignore_warnings_on_exit" value="1"/>
+
+    <exclude-pattern>./workspace/*</exclude-pattern>
+    <exclude-pattern>./manifest/*</exclude-pattern>
+    <exclude-pattern>./extensions/*</exclude-pattern>
+    <exclude-pattern>./vendor/*</exclude-pattern>
+
+    <rule ref="PSR2">
+        <exclude name="Generic.Files.LineLength"/>
+    </rule>
+</ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,4 +10,6 @@
     <rule ref="PSR2">
         <exclude name="Generic.Files.LineLength"/>
     </rule>
+
+    <rule ref="PSR1" />
 </ruleset>

--- a/symphony/conductor
+++ b/symphony/conductor
@@ -1,45 +1,44 @@
 #!/usr/bin/env php
 <?php
-    use Symfony\Component\Console\Application;
-    use SymphonyCms\Installer\Command as Installer;
+use Symfony\Component\Console\Application;
+use SymphonyCms\Installer\Command as Installer;
 
-    // Find out where we are:
-    define('DOCROOT', realpath(__DIR__ . '/../'));
-    define('APP_MODE', 'console');
-    define('VERSION', '3.0.0-alpha.1');
+// Find out where we are:
+define('DOCROOT', realpath(__DIR__ . '/../'));
+define('APP_MODE', 'console');
+define('VERSION', '3.0.0-alpha.1');
 
-    // Set the current timezone, should that not be available default to GMT.
-    if (!date_default_timezone_set(@date_default_timezone_get())) {
-        date_default_timezone_set('GMT');
-    }
+// Set the current timezone, should that not be available default to GMT.
+if (!date_default_timezone_set(@date_default_timezone_get())) {
+    date_default_timezone_set('GMT');
+}
 
-    // Set appropriate error reporting:
-    error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
+// Set appropriate error reporting:
+error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
 
-    // Include autoloader:
-    $autoloader = require_once DOCROOT . '/vendor/autoload.php';
+// Include autoloader:
+$autoloader = require_once DOCROOT . '/vendor/autoload.php';
 
-    $application = new Application('symphony/conductor', VERSION);
+$application = new Application('symphony/conductor', VERSION);
 
-    // Attempt to find all the commands in this project
-    // TODO: Find a better way.
-    foreach ([DOCROOT . '/install', SYMPHONY, EXTENSIONS, WORKSPACE] as $directory) {
-        try {
-            $dir = new DirectoryIterator($directory . '/command');
-            foreach ($dir as $fileinfo) {
-                if ($fileinfo->isDot() || $fileinfo->isDir()) {
-                    continue;
-                }
-
-                // Rely on the commands return the namespace once they are required.
-                $namespace = require_once $fileinfo->getRealPath();
-                $command = $namespace . '\\' . $fileinfo->getBasename('.php');
-
-               $application->add(new $command);
+// Attempt to find all the commands in this project
+foreach ([DOCROOT . '/install', SYMPHONY, EXTENSIONS, WORKSPACE] as $directory) {
+    try {
+        $dir = new DirectoryIterator($directory . '/command');
+        foreach ($dir as $fileinfo) {
+            if ($fileinfo->isDot() || $fileinfo->isDir()) {
+                continue;
             }
-        } catch (Exception $ex) {
 
+            // Rely on the commands return the namespace once they are required.
+            $namespace = require_once $fileinfo->getRealPath();
+            $command = $namespace . '\\' . $fileinfo->getBasename('.php');
+
+            $application->add(new $command);
         }
+    } catch (Exception $ex) {
+        // Skip
     }
+}
 
-    $application->run();
+$application->run();

--- a/symphony/conductor
+++ b/symphony/conductor
@@ -4,13 +4,22 @@
     use SymphonyCms\Installer\Command as Installer;
 
     // Find out where we are:
-    define('DOCROOT', __DIR__ . '/../');
-    define('APP_MODE', isset($_GET['mode']) ? $_GET['mode'] : 'frontend');
+    define('DOCROOT', realpath(__DIR__ . '/../'));
+    define('APP_MODE', 'console');
+    define('VERSION', '3.0.0-alpha.1');
+
+    // Set the current timezone, should that not be available default to GMT.
+    if (!date_default_timezone_set(@date_default_timezone_get())) {
+        date_default_timezone_set('GMT');
+    }
+
+    // Set appropriate error reporting:
+    error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED & ~E_STRICT);
 
     // Include autoloader:
     $autoloader = require_once DOCROOT . '/vendor/autoload.php';
 
-    $application = new Application();
+    $application = new Application('symphony/conductor', VERSION);
     $application->add(new Installer\RequirementsCommmand());
     $application->add(new Installer\InstallCommmand());
     $application->run();

--- a/symphony/conductor
+++ b/symphony/conductor
@@ -1,0 +1,18 @@
+#!/usr/bin/env php
+<?php
+    use Symfony\Component\Console\Application;
+    use SymphonyCms\Installer\Command as Installer;
+
+    // Find out where we are:
+    define('DOCROOT', __DIR__ . '/../');
+    define('APP_MODE', isset($_GET['mode']) ? $_GET['mode'] : 'frontend');
+
+    // Include autoloader:
+    $autoloader = require_once DOCROOT . '/vendor/autoload.php';
+
+    $application = new Application();
+    $application->add(new Installer\RequirementsCommmand());
+    $application->add(new Installer\InstallCommmand());
+    $application->run();
+
+

--- a/symphony/conductor
+++ b/symphony/conductor
@@ -20,8 +20,26 @@
     $autoloader = require_once DOCROOT . '/vendor/autoload.php';
 
     $application = new Application('symphony/conductor', VERSION);
-    $application->add(new Installer\RequirementsCommmand());
-    $application->add(new Installer\InstallCommmand());
+
+    // Attempt to find all the commands in this project
+    // TODO: Find a better way.
+    foreach ([DOCROOT . '/install', SYMPHONY, EXTENSIONS, WORKSPACE] as $directory) {
+        try {
+            $dir = new DirectoryIterator($directory . '/command');
+            foreach ($dir as $fileinfo) {
+                if ($fileinfo->isDot() || $fileinfo->isDir()) {
+                    continue;
+                }
+
+                // Rely on the commands return the namespace once they are required.
+                $namespace = require_once $fileinfo->getRealPath();
+                $command = $namespace . '\\' . $fileinfo->getBasename('.php');
+
+               $application->add(new $command);
+            }
+        } catch (Exception $ex) {
+
+        }
+    }
+
     $application->run();
-
-

--- a/symphony/lib/core/class.configuration.php
+++ b/symphony/lib/core/class.configuration.php
@@ -200,7 +200,7 @@ class Configuration
             $file = CONFIG;
         }
 
-        $string = "<?php" . PHP_EOL . '$settings = ' . (string)$this . ";" . PHP_EOL;
+        $string = "<?php" . PHP_EOL . 'return $settings = ' . (string)$this . ";" . PHP_EOL;
 
         return General::writeFile($file, $string, $permissions);
     }

--- a/symphony/lib/core/class.configuration.php
+++ b/symphony/lib/core/class.configuration.php
@@ -172,23 +172,11 @@ class Configuration
      */
     public function __toString()
     {
-        $string = 'array(';
-
-        foreach ($this->_properties as $group => $data) {
-            $string .= str_repeat(PHP_EOL, 3) . "\t\t###### ".strtoupper($group)." ######";
-            $string .= PHP_EOL . "\t\t'$group' => array(";
-
-            foreach ($data as $key => $value) {
-                $string .= PHP_EOL . "\t\t\t'$key' => ".(strlen($value) > 0 ? var_export($value, true) : 'null').",";
-            }
-
-            $string .= PHP_EOL . "\t\t),";
-            $string .= PHP_EOL . "\t\t########";
-        }
-
-        $string .= PHP_EOL . "\t)";
-
-        return $string;
+        return str_replace(
+            ['\n'],
+            [PHP_EOL],
+            var_export($this->_properties, true)
+        );
     }
 
     /**
@@ -212,7 +200,7 @@ class Configuration
             $file = CONFIG;
         }
 
-        $string = "<?php\n\t\$settings = " . (string)$this . ";\n";
+        $string = "<?php" . PHP_EOL . '$settings = ' . (string)$this . ";" . PHP_EOL;
 
         return General::writeFile($file, $string, $permissions);
     }

--- a/symphony/lib/core/class.genericexceptionhandler.php
+++ b/symphony/lib/core/class.genericexceptionhandler.php
@@ -160,7 +160,7 @@ class GenericExceptionHandler
 
         $queries = null;
 
-        if (is_object(Symphony::Database())) {
+        if (is_object(Symphony::Database()) && Symphony::Database()->isConnected()) {
             $debug = Symphony::Database()->debug();
 
             if (!empty($debug)) {

--- a/symphony/lib/core/class.symphony.php
+++ b/symphony/lib/core/class.symphony.php
@@ -14,88 +14,92 @@ use Monolog\Logger;
 abstract class Symphony implements Singleton
 {
     /**
+     * An instance of the Cookies class
+     *
+     * @var Cookies
+     */
+    public static $Cookies = null;
+    /**
+     * An instance of the Session class
+     *
+     * @var Session
+     */
+    public static $Session = null;
+    /**
+     * An instance of the SessionFlash class
+     *
+     * @var Session
+     */
+    public static $Flash = null;
+    /**
+     * An instance of the currently logged in Author
+     *
+     * @var Author
+     */
+    public static $Author = null;
+    /**
      * An instance of the Symphony class, either `Administration` or `Frontend`.
+     *
      * @var Symphony
      */
     protected static $_instance = null;
-
     /**
      * An instance of the Profiler class
+     *
      * @var Profiler
      */
     protected static $Profiler = null;
-
     /**
      * An instance of the `Configuration` class
+     *
      * @var Configuration
      */
     private static $Configuration = null;
-
     /**
      * An instance of the `Database` class
+     *
      * @var MySQL
      */
     private static $Database = null;
-
     /**
      * An instance of the `ExtensionManager` class
+     *
      * @var ExtensionManager
      */
     private static $ExtensionManager = null;
-
     /**
      * An instance of the `Log` class
+     *
      * @var Log
      */
     private static $Log = null;
-
     /**
      * The current page namespace, used for translations
+     *
      * @since Symphony 2.3
      * @var string
      */
     private static $namespace = false;
-
-    /**
-     * An instance of the Cookies class
-     * @var Cookies
-     */
-    public static $Cookies = null;
-
-    /**
-     * An instance of the Session class
-     * @var Session
-     */
-    public static $Session = null;
-
-    /**
-     * An instance of the SessionFlash class
-     * @var Session
-     */
-    public static $Flash = null;
-
-    /**
-     * An instance of the currently logged in Author
-     * @var Author
-     */
-    public static $Author = null;
-
     /**
      * A previous exception that has been fired. Defaults to null.
+     *
      * @since Symphony 2.3.2
      * @var Exception
      */
     private static $exception = null;
+    /**
+     * The version of the available Symphony upgrade, if available.
+     * @var string
+     */
+    private static $migrationVersion = null;
 
     /**
      * The Symphony constructor initialises the class variables of Symphony. At present
      * constructor has a couple of responsibilities:
      * - Start a profiler instance
-     * - If magic quotes are enabled, clean `$_SERVER`, `$_COOKIE`, `$_GET`, `$_POST` and `$_REQUEST` arrays.
+     * - If magic quotes are enabled, clean `$_SERVER`, `$_COOKIE`, `$_GET` and `$_POST` arrays
      * - Initialise the correct Language for the currently logged in Author.
      * - Start the session and adjust the error handling if the user is logged in
-     *
-     * The `$_REQUEST` array has been added in 2.7.0
      */
     protected function __construct()
     {
@@ -106,18 +110,13 @@ abstract class Symphony implements Singleton
             General::cleanArray($_COOKIE);
             General::cleanArray($_GET);
             General::cleanArray($_POST);
-            General::cleanArray($_REQUEST);
         }
 
         // Initialize language management
         Lang::initialize();
         Lang::set(self::$Configuration->get('lang', 'symphony'));
 
-        $this->initialiseLog();
-
-        GenericExceptionHandler::initialise(self::Log());
-        GenericErrorHandler::initialise(self::Log());
-
+        $this->initialiseErrorHandler();
         $this->initialiseDatabase();
         $this->initialiseExtensionManager();
         $this->initialiseSessionAndCookies();
@@ -129,6 +128,480 @@ abstract class Symphony implements Singleton
 
         // Engine is ready.
         self::$Profiler->sample('Engine Initialisation');
+    }
+
+    /**
+     * Setter for `$Log`. This function uses the configuration
+     * settings in the 'log' group in the Configuration to create an instance. Date
+     * formatting options are also retrieved from the configuration.
+     *
+     * @param string $filename (optional)
+     *  The file to write the log to, if omitted this will default to `ACTIVITY_LOG`
+     * @throws Exception
+     * @return bool|void
+     */
+    public static function initialiseLog($filename = null)
+    {
+        if (self::$Log instanceof Log) {
+            return true;
+        }
+
+        if (is_null($filename)) {
+            $filename = ACTIVITY_LOG;
+        }
+
+        // Get the Handler from the Configuration
+        $handler = self::Configuration()->get('handler', 'log');
+        $context = array_merge(
+            array(
+                'vars' => array(
+                    'filename' => $filename
+                )
+            ),
+            self::Configuration()->get()
+        );
+
+        // Create the base handler
+        if (is_array($handler['args'])) {
+            array_walk($handler['args'], 'General::replacePlaceholdersWithContext', $context);
+            $reflection = new ReflectionClass($handler['class']);
+            $handler = $reflection->newInstanceArgs($handler['args']);
+        } else {
+            $handler = new \Monolog\Handler\StreamHandler($filename);
+        }
+
+        // Create the base formatter
+        if ($format = self::Configuration()->get('formatter', 'log')) {
+            array_walk($format['args'], 'General::replacePlaceholdersWithContext', $context);
+            $reflection = new ReflectionClass($format['class']);
+            $formatter = $reflection->newInstanceArgs($format['args']);
+            $handler->setFormatter($formatter);
+        }
+
+        // Create the log object
+        $logger = new Logger(basename($filename));
+        $logger->pushHandler($handler);
+
+        self::$Log = new Log($logger);
+    }
+
+    /**
+     * Accessor for the current `Configuration` instance. This contains
+     * representation of the the Symphony config file.
+     *
+     * @return Configuration
+     */
+    public static function Configuration()
+    {
+        return self::$Configuration;
+    }
+
+    /**
+     * Accessor for the current `Log` instance
+     *
+     * @since Symphony 2.3
+     * @return Log
+     */
+    public static function Log()
+    {
+        return self::$Log;
+    }
+
+    /**
+     * This will initialise the Database class and attempt to create a connection
+     * using the connection details provided in the Symphony configuration. If any
+     * errors occur whilst doing so, a Symphony Error Page is displayed.
+     *
+     * @throws SymphonyErrorPage
+     * @return boolean
+     *  This function will return true if the `$Database` was
+     *  initialised successfully.
+     */
+    public static function initialiseDatabase()
+    {
+        self::setDatabase();
+        $details = self::Configuration()->get('database');
+
+        try {
+            if (!self::Database()->connect($details['host'], $details['user'], $details['password'],
+                $details['port'], $details['db'])
+            ) {
+                return false;
+            }
+
+            if (!self::Database()->isConnected()) {
+                return false;
+            }
+
+            self::Database()->setPrefix($details['tbl_prefix']);
+            self::Database()->setTimeZone(self::Configuration()->get('timezone', 'region'));
+
+            if (isset($details['query_caching'])) {
+                if ($details['query_caching'] === 'off') {
+                    self::Database()->disableCaching();
+                } elseif ($details['query_caching'] === 'on') {
+                    self::Database()->enableCaching();
+                }
+            }
+
+            if (isset($details['query_logging'])) {
+                if ($details['query_logging'] === 'off') {
+                    self::Database()->disableLogging();
+                } elseif ($details['query_logging'] === 'on') {
+                    self::Database()->enableLogging();
+                }
+            }
+        } catch (DatabaseException $e) {
+            self::throwCustomError(
+                $e->getDatabaseErrorCode() . ': ' . $e->getDatabaseErrorMessage(),
+                __('Symphony Database Error'),
+                Page::HTTP_STATUS_ERROR,
+                'database',
+                array(
+                    'error' => $e,
+                    'message' => __('There was a problem whilst attempting to establish a database connection. Please check all connection information is correct.') . ' ' . __('The following error was returned:')
+                )
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * Setter for `$Database`, accepts a Database object. If `$database`
+     * is omitted, this function will set `$Database` to be of the `MySQL`
+     * class.
+     *
+     * @since Symphony 2.3
+     * @param stdClass $database (optional)
+     *  The class to handle all Database operations, if omitted this function
+     *  will set `self::$Database` to be an instance of the `MySQL` class.
+     * @return boolean
+     *  This function will always return true
+     */
+    public static function setDatabase(stdClass $database = null)
+    {
+        if (self::Database()) {
+            return true;
+        }
+
+        self::$Database = !is_null($database) ? $database : new MySQL;
+
+        return true;
+    }
+
+    /**
+     * Accessor for the current `$Database` instance.
+     *
+     * @return MySQL
+     */
+    public static function Database()
+    {
+        return self::$Database;
+    }
+
+    /**
+     * A wrapper for throwing a new Symphony Error page.
+     *
+     * This methods sets the `GenericExceptionHandler::$enabled` value to `true`.
+     *
+     * @see core.SymphonyErrorPage
+     * @param string|XMLElement $message
+     *  A description for this error, which can be provided as a string
+     *  or as an XMLElement.
+     * @param string $heading
+     *  A heading for the error page
+     * @param integer $status
+     *  Properly sets the HTTP status code for the response. Defaults to
+     *  `Page::HTTP_STATUS_ERROR`. Use `Page::HTTP_STATUS_XXX` to set this value.
+     * @param string $template
+     *  A string for the error page template to use, defaults to 'generic'. This
+     *  can be the name of any template file in the `TEMPLATES` directory.
+     *  A template using the naming convention of `tpl.*.php`.
+     * @param array $additional
+     *  Allows custom information to be passed to the Symphony Error Page
+     *  that the template may want to expose, such as custom Headers etc.
+     * @throws SymphonyErrorPage
+     */
+    public static function throwCustomError(
+        $message,
+        $heading = 'Symphony Fatal Error',
+        $status = Page::HTTP_STATUS_ERROR,
+        $template = 'generic',
+        array $additional = array()
+    ) {
+        GenericExceptionHandler::$enabled = true;
+        throw new SymphonyErrorPage($message, $heading, $template, $additional, $status);
+    }
+
+    /**
+     * Setter for `$ExtensionManager` using the current
+     * Symphony instance as the parent. If for some reason this fails,
+     * a Symphony Error page will be thrown
+     *
+     * @param boolean $force (optional)
+     *  When set to true, this function will always create a new
+     *  instance of ExtensionManager, replacing self::$ExtensionManager.
+     * @return void
+     */
+    public static function initialiseExtensionManager($force = false)
+    {
+        if (!$force && self::$ExtensionManager instanceof ExtensionManager) {
+            return;
+        }
+
+        self::$ExtensionManager = new ExtensionManager;
+
+        if (!(self::$ExtensionManager instanceof ExtensionManager)) {
+            self::throwCustomError(__('Error creating Symphony extension manager.'));
+        }
+    }
+
+    /**
+     * Setter for `$Session`. This will use PHP's parse_url
+     * function on the current URL to set a session using the `session_name`
+     * defined in the Symphony configuration. The is either admin or public.
+     * The session will last for the time defined in configuration.
+     *
+     * @since Symphony 3.0.0
+     */
+    public function initialiseSessionAndCookies()
+    {
+        $cookie_path = @parse_url(URL, PHP_URL_PATH);
+        $cookie_path = '/' . trim($cookie_path, '/');
+
+        $timeout = $this->getSessionTimeout();
+
+        $name = null;
+        if (class_exists('Administration', false)) {
+            $name = self::Configuration()->get('admin_session_name', 'session');
+        } else {
+            $name = self::Configuration()->get('public_session_name', 'session');
+        }
+
+        if (is_null($name)) {
+            $name = 'symphony';
+        }
+
+        // The handler accepts a database in a move towards dependency injection
+        $handler = new DatabaseSessionHandler(self::Database(), array(
+            'session_lifetime' => $timeout
+        ), $name);
+
+        // The session accepts a handler in a move towards dependency injection
+        self::$Session = new Session($handler, array(
+            'session_gc_probability' => self::Configuration()->get('session_gc_probability', 'session'),
+            'session_gc_divisor' => self::Configuration()->get('session_gc_divisor', 'session'),
+            'session_gc_maxlifetime' => $timeout,
+            'session_cookie_lifetime' => $timeout,
+            'session_cookie_path' => $cookie_path,
+            'session_cookie_domain' => null,
+            'session_cookie_secure' => (defined(__SECURE__) ? true : false),
+            'session_cookie_httponly' => true
+        ), $name);
+
+        // Initialise the cookie handler
+        self::$Cookies = new Cookies(array(
+            'domain' => self::Session()->getDomain(),
+            'path' => $cookie_path,
+            'expires' => time() + $timeout,
+            'secure' => (defined(__SECURE__) ? true : false),
+            'httponly' => true
+        ));
+
+        // Start the session
+        self::Session()->start();
+
+        // The flash accepts a session in a move towards dependency injection
+        self::$Flash = new SessionFlash(self::Session());
+
+        // Fetch the current cookies from the header
+        self::Cookies()->fetch();
+    }
+
+    /**
+     * Gets the configuerd session timeout as seconds, based on the environment instance
+     *
+     * @return int
+     *  The seconds
+     */
+    private function getSessionTimeout()
+    {
+        if (class_exists('Administration', false)) {
+            $time = (self::Configuration()->get('admin_session_expires',
+                'symphony') ? self::Configuration()->get('admin_session_expires', 'symphony') : '2 weeks');
+        } else {
+            $time = (self::Configuration()->get('public_session_expires',
+                'symphony') ? self::Configuration()->get('public_session_expires', 'symphony') : '2 weeks');
+        }
+
+        if (is_string($time) && !is_numeric($time)) {
+            $time = DateTimeObj::stringToSeconds($time);
+        }
+
+        return $time;
+    }
+
+    /**
+     * Accessor for the current `$Session` instance.
+     *
+     * @since 3.0.0
+     * @return Session
+     */
+    public static function Session()
+    {
+        return self::$Session;
+    }
+
+    /**
+     * Accessor for the current `$Cookies` instance.
+     *
+     * @since 2.0.0
+     * @return Cookies
+     */
+    public static function Cookies()
+    {
+        return self::$Cookies;
+    }
+
+    /**
+     * This function determines whether an there is a currently logged in
+     * Author for Symphony by using the `$Session`'s username
+     * and password. If an Author is found, they will be logged in, otherwise
+     * the `$Session` will be destroyed.
+     *
+     * @see login()
+     * @return boolean
+     */
+    public static function isLoggedIn()
+    {
+        // Check to see if Symphony exists, or if we already have an Author instance.
+        if (is_null(self::$_instance) || self::$Author) {
+            return true;
+        }
+
+        // No author instance found, attempt to log in with the cookied credentials
+        return self::login(self::Session()->get('username'), self::Session()->get('pass'), true);
+    }
+
+    /**
+     * Attempts to log an Author in given a username and password.
+     * If the password is not hashed, it will be hashed using the sha1
+     * algorithm. The username and password will be sanitized before
+     * being used to query the Database. If an Author is found, they
+     * will be logged in and the sanitized username and password (also hashed)
+     * will be saved as values in the `$Session`.
+     *
+     * @see toolkit.Cryptography#hash()
+     * @throws DatabaseException
+     * @param string $username
+     *  The Author's username. This will be sanitized before use.
+     * @param string $password
+     *  The Author's password. This will be sanitized and then hashed before use
+     * @param boolean $isHash
+     *  If the password provided is already hashed, setting this parameter to
+     *  true will stop it becoming rehashed. By default it is false.
+     * @return boolean
+     *  True if the Author was logged in, false otherwise
+     */
+    public static function login($username, $password, $isHash = false)
+    {
+        $username = trim(self::Database()->cleanValue($username));
+        $password = trim(self::Database()->cleanValue($password));
+
+        if (strlen($username) > 0 && strlen($password) > 0) {
+            $author = AuthorManager::fetch('id', 'ASC', 1, null, sprintf(
+                "`username` = '%s'",
+                $username
+            ));
+
+            if (!empty($author) && Cryptography::compare($password, current($author)->get('password'), $isHash)) {
+                self::$Author = current($author);
+
+                // Only migrate hashes if there is no update available as the update might change the tbl_authors table.
+                if (self::isUpgradeAvailable() === false && Cryptography::requiresMigration(self::$Author->get('password'))) {
+                    self::$Author->set('password', Cryptography::hash($password));
+
+                    self::Database()->update(array('password' => self::$Author->get('password')), 'tbl_authors',
+                        " `id` = ?", array(self::$Author->get('id'))
+                    );
+                }
+
+                self::Session()->set('username', $username);
+                self::Session()->set('pass', self::$Author->get('password'));
+
+                self::Database()->update(array(
+                    'last_seen' => DateTimeObj::get('Y-m-d H:i:s')
+                ),
+                    'tbl_authors',
+                    " `id` = ?",
+                    array(self::$Author->get('id'))
+                );
+
+                // Only set custom author language in the backend
+                if (class_exists('Administration', false)) {
+                    Lang::set(self::$Author->get('language'));
+                }
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if an update is available and applicable for the current installation.
+     *
+     * @since Symphony 2.3.1
+     * @return boolean
+     */
+    public static function isUpgradeAvailable()
+    {
+        if (self::isInstallerAvailable()) {
+            $migration_version = self::getMigrationVersion();
+            $current_version = Symphony::Configuration()->get('version', 'symphony');
+
+            return version_compare($current_version, $migration_version, '<');
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if the installer/upgrader is available.
+     *
+     * @since Symphony 2.3.1
+     * @return boolean
+     */
+    public static function isInstallerAvailable()
+    {
+        return file_exists(DOCROOT . '/install/index.php');
+    }
+
+    /**
+     * Returns the most recent version found in the `/install/migrations` folder.
+     * Returns a version string to be used in `version_compare()` if an updater
+     * has been found. Returns `FALSE` otherwise.
+     *
+     * @since Symphony 2.3.1
+     * @return string|boolean
+     */
+    public static function getMigrationVersion()
+    {
+        if (null === self::$migrationVersion && self::isInstallerAvailable()) {
+            $migrations = scandir(DOCROOT . '/install/migrations');
+            $migration_file = end($migrations);
+
+            include_once DOCROOT . '/install/migrations/' . $migration_file;
+
+            $migration_class = 'SymphonyCms\\Installer\\Migrations\\migration_' . str_replace('.', '', substr($migration_file, 0, -4));
+            self::$migrationVersion = call_user_func(array($migration_class, 'getVersion'));
+        } else {
+            self::$migrationVersion = false;
+        }
+
+        return self::$migrationVersion;
     }
 
     /**
@@ -188,19 +661,9 @@ abstract class Symphony implements Singleton
         // Set date format throughout the system
         define_safe('__SYM_DATE_FORMAT__', self::Configuration()->get('date_format', 'region'));
         define_safe('__SYM_TIME_FORMAT__', self::Configuration()->get('time_format', 'region'));
-        define_safe('__SYM_DATETIME_FORMAT__', __SYM_DATE_FORMAT__ . self::Configuration()->get('datetime_separator', 'region') . __SYM_TIME_FORMAT__);
+        define_safe('__SYM_DATETIME_FORMAT__',
+            __SYM_DATE_FORMAT__ . self::Configuration()->get('datetime_separator', 'region') . __SYM_TIME_FORMAT__);
         DateTimeObj::setSettings(self::Configuration()->get('region'));
-    }
-
-    /**
-     * Accessor for the current `Configuration` instance. This contains
-     * representation of the the Symphony config file.
-     *
-     * @return Configuration
-     */
-    public static function Configuration()
-    {
-        return self::$Configuration;
     }
 
     /**
@@ -226,154 +689,6 @@ abstract class Symphony implements Singleton
     }
 
     /**
-     * Setter for `$Log`. This function uses the configuration
-     * settings in the 'log' group in the Configuration to create an instance. Date
-     * formatting options are also retrieved from the configuration.
-     *
-     * @param string $filename (optional)
-     *  The file to write the log to, if omitted this will default to `ACTIVITY_LOG`
-     * @throws Exception
-     * @return bool|void
-     */
-    public static function initialiseLog($filename = null)
-    {
-        if (self::$Log instanceof Log) {
-            return true;
-        }
-
-        if (is_null($filename)) {
-            $filename = ACTIVITY_LOG;
-        }
-
-        // Get the Handler from the Configuration
-        $handler = self::Configuration()->get('handler', 'log');
-        $context = array_merge(array(
-                'vars' => array(
-                    'filename' => $filename
-                )
-            ),
-            self::Configuration()->get()
-        );
-
-        // Create the base handler
-        if (is_array($handler['args'])) {
-            array_walk($handler['args'], 'General::replacePlaceholdersWithContext', $context);
-            $reflection = new ReflectionClass($handler['class']);
-            $handler = $reflection->newInstanceArgs($handler['args']);
-        } else {
-            $handler = new \Monolog\Handler\StreamHandler($filename);
-        }
-
-        // Create the base formatter
-        if ($format = self::Configuration()->get('formatter', 'log')) {
-            array_walk($format['args'], 'General::replacePlaceholdersWithContext', $context);
-            $reflection = new ReflectionClass($format['class']);
-            $formatter = $reflection->newInstanceArgs($format['args']);
-            $handler->setFormatter($formatter);
-        }
-
-        // Create the log object
-        $logger = new Logger(basename($filename));
-        $logger->pushHandler($handler);
-
-        self::$Log = new Log($logger);
-    }
-
-    /**
-     * Accessor for the current `Log` instance
-     *
-     * @since Symphony 2.3
-     * @return Log
-     */
-    public static function Log()
-    {
-        return self::$Log;
-    }
-
-    /**
-     * Setter for `$Session`. This will use PHP's parse_url
-     * function on the current URL to set a session using the `session_name`
-     * defined in the Symphony configuration. The is either admin or public.
-     * The session will last for the time defined in configuration.
-     *
-     * @since Symphony 3.0.0
-     */
-    public function initialiseSessionAndCookies()
-    {
-        $name = '';
-        $timeout = $this->getSessionTimeout();
-        $cookie_path = DIRROOT === '' ? '/' : DIRROOT;
-
-        $name = null;
-        if (class_exists('Administration', false)) {
-            $name = self::Configuration()->get('admin_session_name', 'session');
-        } else {
-            $name = self::Configuration()->get('public_session_name', 'session');
-        }
-
-        if (is_null($name)) {
-            $name = 'symphony';
-        }
-
-        // The handler accepts a database in a move towards dependency injection
-        $handler = new DatabaseSessionHandler(self::Database(), array(
-            'session_lifetime' => $timeout
-        ), $name);
-
-        // The session accepts a handler in a move towards dependency injection
-        self::$Session = new Session($handler, array(
-            'session_gc_probability' => self::Configuration()->get('session_gc_probability', 'session'),
-            'session_gc_divisor' => self::Configuration()->get('session_gc_divisor', 'session'),
-            'session_gc_maxlifetime' => $timeout,
-            'session_cookie_lifetime' => $timeout,
-            'session_cookie_path' => $cookie_path,
-            'session_cookie_domain' => null,
-            'session_cookie_secure' => (defined(__SECURE__) ? true : false),
-            'session_cookie_httponly' => true
-        ), $name);
-
-        // Initialise the cookie handler
-        self::$Cookies = new Cookies(array(
-            'domain' => self::Session()->getDomain(),
-            'path' => $cookie_path,
-            'expires' => time() + $timeout,
-            'secure' => (defined(__SECURE__) ? true : false),
-            'httponly' => true
-        ));
-
-        // Start the session
-        self::Session()->start();
-
-        // The flash accepts a session in a move towards dependency injection
-        self::$Flash = new SessionFlash(self::Session());
-
-        // Fetch the current cookies from the header
-        self::Cookies()->fetch();
-    }
-
-    /**
-     * Accessor for the current `$Session` instance.
-     *
-     * @since 3.0.0
-     * @return Session
-     */
-    public static function Session()
-    {
-        return self::$Session;
-    }
-
-    /**
-     * Accessor for the current `$Cookies` instance.
-     *
-     * @since 2.0.0
-     * @return Cookies
-     */
-    public static function Cookies()
-    {
-        return self::$Cookies;
-    }
-
-    /**
      * Accessor for the current `$Flash` instance.
      *
      * @since 3.0.0
@@ -382,49 +697,6 @@ abstract class Symphony implements Singleton
     public static function Flash()
     {
         return self::$Flash;
-    }
-
-    /**
-     * Gets the configuerd session timeout as seconds, based on the environment instance
-     * @return int
-     *  The seconds
-     */
-    private function getSessionTimeout()
-    {
-        if (class_exists('Administration', false)) {
-            $time = (self::Configuration()->get('admin_session_expires', 'symphony') ? self::Configuration()->get('admin_session_expires', 'symphony') : '2 weeks');
-        } else {
-            $time = (self::Configuration()->get('public_session_expires', 'symphony') ? self::Configuration()->get('public_session_expires', 'symphony') : '2 weeks');
-        }
-
-        if (is_string($time) && !is_numeric($time)) {
-            $time = DateTimeObj::stringToSeconds($time);
-        }
-
-        return $time;
-    }
-
-    /**
-     * Setter for `$ExtensionManager` using the current
-     * Symphony instance as the parent. If for some reason this fails,
-     * a Symphony Error page will be thrown
-     *
-     * @param boolean $force (optional)
-     *  When set to true, this function will always create a new
-     *  instance of ExtensionManager, replacing self::$ExtensionManager.
-     * @return void
-     */
-    public static function initialiseExtensionManager($force = false)
-    {
-        if (!$force && self::$ExtensionManager instanceof ExtensionManager) {
-            return;
-        }
-
-        self::$ExtensionManager = new ExtensionManager;
-
-        if (!(self::$ExtensionManager instanceof ExtensionManager)) {
-            self::throwCustomError(__('Error creating Symphony extension manager.'));
-        }
     }
 
     /**
@@ -439,97 +711,6 @@ abstract class Symphony implements Singleton
     }
 
     /**
-     * Setter for `$Database`, accepts a Database object. If `$database`
-     * is omitted, this function will set `$Database` to be of the `MySQL`
-     * class.
-     *
-     * @since Symphony 2.3
-     * @param stdClass $database (optional)
-     *  The class to handle all Database operations, if omitted this function
-     *  will set `self::$Database` to be an instance of the `MySQL` class.
-     * @return boolean
-     *  This function will always return true
-     */
-    public static function setDatabase(stdClass $database = null)
-    {
-        if (self::Database()) {
-            return true;
-        }
-
-        self::$Database = !is_null($database) ? $database : new MySQL;
-
-        return true;
-    }
-
-    /**
-     * Accessor for the current `$Database` instance.
-     *
-     * @return MySQL
-     */
-    public static function Database()
-    {
-        return self::$Database;
-    }
-
-    /**
-     * This will initialise the Database class and attempt to create a connection
-     * using the connection details provided in the Symphony configuration. If any
-     * errors occur whilst doing so, a Symphony Error Page is displayed.
-     *
-     * @throws SymphonyErrorPage
-     * @return boolean
-     *  This function will return true if the `$Database` was
-     *  initialised successfully.
-     */
-    public static function initialiseDatabase()
-    {
-        self::setDatabase();
-        $details = self::Configuration()->get('database');
-
-        try {
-            if (!self::Database()->connect($details['host'], $details['user'], $details['password'], $details['port'], $details['db'])) {
-                return false;
-            }
-
-            if (!self::Database()->isConnected()) {
-                return false;
-            }
-
-            self::Database()->setPrefix($details['tbl_prefix']);
-            self::Database()->setTimeZone(self::Configuration()->get('timezone', 'region'));
-
-            if (isset($details['query_caching'])) {
-                if ($details['query_caching'] === 'off') {
-                    self::Database()->disableCaching();
-                } elseif ($details['query_caching'] === 'on') {
-                    self::Database()->enableCaching();
-                }
-            }
-
-            if (isset($details['query_logging'])) {
-                if ($details['query_logging'] === 'off') {
-                    self::Database()->disableLogging();
-                } elseif ($details['query_logging'] === 'on') {
-                    self::Database()->enableLogging();
-                }
-            }
-        } catch (DatabaseException $e) {
-            self::throwCustomError(
-                $e->getDatabaseErrorCode() . ': ' . $e->getDatabaseErrorMessage(),
-                __('Symphony Database Error'),
-                Page::HTTP_STATUS_ERROR,
-                'database',
-                array(
-                    'error' => $e,
-                    'message' => __('There was a problem whilst attempting to establish a database connection. Please check all connection information is correct.') . ' ' . __('The following error was returned:')
-                )
-            );
-        }
-
-        return true;
-    }
-
-    /**
      * Accessor for the current `$Author` instance.
      *
      * @since Symphony 2.5.0
@@ -538,72 +719,6 @@ abstract class Symphony implements Singleton
     public static function Author()
     {
         return self::$Author;
-    }
-
-    /**
-     * Attempts to log an Author in given a username and password.
-     * If the password is not hashed, it will be hashed using the sha1
-     * algorithm. The username and password will be sanitized before
-     * being used to query the Database. If an Author is found, they
-     * will be logged in and the sanitized username and password (also hashed)
-     * will be saved as values in the `$Session`.
-     *
-     * @see toolkit.Cryptography#hash()
-     * @throws DatabaseException
-     * @param string $username
-     *  The Author's username. This will be sanitized before use.
-     * @param string $password
-     *  The Author's password. This will be sanitized and then hashed before use
-     * @param boolean $isHash
-     *  If the password provided is already hashed, setting this parameter to
-     *  true will stop it becoming rehashed. By default it is false.
-     * @return boolean
-     *  True if the Author was logged in, false otherwise
-     */
-    public static function login($username, $password, $isHash = false)
-    {
-        $username = trim(self::Database()->cleanValue($username));
-        $password = trim(self::Database()->cleanValue($password));
-
-        if (strlen($username) > 0 && strlen($password) > 0) {
-            $author = AuthorManager::fetch('id', 'ASC', 1, null, sprintf(
-                "`username` = '%s'",
-                $username
-            ));
-
-            if (!empty($author) && Cryptography::compare($password, current($author)->get('password'), $isHash)) {
-                self::$Author = current($author);
-
-                // Only migrate hashes if there is no update available as the update might change the tbl_authors table.
-                if (self::isUpgradeAvailable() === false && Cryptography::requiresMigration(self::$Author->get('password'))) {
-                    self::$Author->set('password', Cryptography::hash($password));
-
-                    self::Database()->update(array('password' => self::$Author->get('password')), 'tbl_authors',
-                        " `id` = ?", array(self::$Author->get('id'))
-                    );
-                }
-
-                self::Session()->set('username', $username);
-                self::Session()->set('pass', self::$Author->get('password'));
-
-                self::Database()->update(array(
-                    'last_seen' => DateTimeObj::get('Y-m-d H:i:s')
-                    ),
-                    'tbl_authors',
-                    " `id` = ?",
-                    array(self::$Author->get('id'))
-                );
-
-                // Only set custom author language in the backend
-                if (class_exists('Administration', false)) {
-                    Lang::set(self::$Author->get('language'));
-                }
-
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /**
@@ -632,12 +747,12 @@ abstract class Symphony implements Singleton
 
         if ($tokenLength === 6 || $tokenLength === 16) {
             $row = self::Database()->fetchRow(0, "
-                SELECT `a`.`id`, `a`.`username`, `a`.`password`
-                FROM `tbl_authors` AS `a`, `tbl_forgotpass` AS `f`
-                WHERE `a`.`id` = `f`.`author_id`
-                AND `f`.`expiry` > ?
-                AND `f`.`token` = ?
-                LIMIT 1",
+            SELECT `a`.`id`, `a`.`username`, `a`.`password`
+            FROM `tbl_authors` AS `a`, `tbl_forgotpass` AS `f`
+            WHERE `a`.`id` = `f`.`author_id`
+            AND `f`.`expiry` > ?
+            AND `f`.`token` = ?
+            LIMIT 1",
                 array(
                     DateTimeObj::getGMT('c'),
                     $token
@@ -648,12 +763,12 @@ abstract class Symphony implements Singleton
         } else {
             $row = self::Database()->fetchRow(0, sprintf(
                 "SELECT `id`, `username`, `password`
-                FROM `tbl_authors`
-                WHERE SUBSTR(%s(CONCAT(`username`, `password`)), 1, 8) = ?
-                AND `auth_token_active` = 'yes'
-                LIMIT 1",
+            FROM `tbl_authors`
+            WHERE SUBSTR(%s(CONCAT(`username`, `password`)), 1, 8) = ?
+            AND `auth_token_active` = 'yes'
+            LIMIT 1",
                 'SHA1'
-                ),
+            ),
                 array($token)
             );
         }
@@ -662,9 +777,10 @@ abstract class Symphony implements Singleton
             self::$Author = AuthorManager::fetchByID($row['id']);
             self::Session()->set('username', $row['username']);
             self::Session()->set('pass', $row['password']);
-            self::Database()->update(array('last_seen' => DateTimeObj::getGMT('Y-m-d H:i:s')), 'tbl_authors', "`id` = ?", array(
-                $row['id']
-            ));
+            self::Database()->update(array('last_seen' => DateTimeObj::getGMT('Y-m-d H:i:s')), 'tbl_authors',
+                "`id` = ?", array(
+                    $row['id']
+                ));
 
             return true;
         }
@@ -684,101 +800,14 @@ abstract class Symphony implements Singleton
     }
 
     /**
-     * This function determines whether an there is a currently logged in
-     * Author for Symphony by using the `$Session`'s username
-     * and password. If an Author is found, they will be logged in, otherwise
-     * the `$Session` will be destroyed.
+     * Accessor for `self::$exception`.
      *
-     * @see login()
-     * @return boolean
+     * @since Symphony 2.3.2
+     * @return Exception|null
      */
-    public static function isLoggedIn()
+    public static function getException()
     {
-        // Check to see if Symphony exists, or if we already have an Author instance.
-        if (is_null(self::$_instance) || self::$Author) {
-            return true;
-        }
-
-        // No author instance found, attempt to log in with the cookied credentials
-        return self::login(self::Session()->get('username'), self::Session()->get('pass'), true);
-    }
-
-    /**
-     * Returns the most recent version found in the `/install/migrations` folder.
-     * Returns a version string to be used in `version_compare()` if an updater
-     * has been found. Returns `FALSE` otherwise.
-     *
-     * @since Symphony 2.3.1
-     * @return string|boolean
-     */
-    public static function getMigrationVersion()
-    {
-        if (self::isInstallerAvailable()) {
-            $migrations = scandir(DOCROOT . '/install/migrations');
-            $migration_file = end($migrations);
-            $migration_class = 'migration_' . str_replace('.', '', substr($migration_file, 0, -4));
-            return call_user_func(array($migration_class, 'getVersion'));
-        }
-
-        return false;
-    }
-
-    /**
-     * Checks if an update is available and applicable for the current installation.
-     *
-     * @since Symphony 2.3.1
-     * @return boolean
-     */
-    public static function isUpgradeAvailable()
-    {
-        if (self::isInstallerAvailable()) {
-            $migration_version = self::getMigrationVersion();
-            $current_version = Symphony::Configuration()->get('version', 'symphony');
-
-            return version_compare($current_version, $migration_version, '<');
-        }
-
-        return false;
-    }
-
-    /**
-     * Checks if the installer/upgrader is available.
-     *
-     * @since Symphony 2.3.1
-     * @return boolean
-     */
-    public static function isInstallerAvailable()
-    {
-        return file_exists(DOCROOT . '/install/index.php');
-    }
-
-    /**
-     * A wrapper for throwing a new Symphony Error page.
-     *
-     * This methods sets the `GenericExceptionHandler::$enabled` value to `true`.
-     *
-     * @see core.SymphonyErrorPage
-     * @param string|XMLElement $message
-     *  A description for this error, which can be provided as a string
-     *  or as an XMLElement.
-     * @param string $heading
-     *  A heading for the error page
-     * @param integer $status
-     *  Properly sets the HTTP status code for the response. Defaults to
-     *  `Page::HTTP_STATUS_ERROR`. Use `Page::HTTP_STATUS_XXX` to set this value.
-     * @param string $template
-     *  A string for the error page template to use, defaults to 'generic'. This
-     *  can be the name of any template file in the `TEMPLATES` directory.
-     *  A template using the naming convention of `tpl.*.php`.
-     * @param array $additional
-     *  Allows custom information to be passed to the Symphony Error Page
-     *  that the template may want to expose, such as custom Headers etc.
-     * @throws SymphonyErrorPage
-     */
-    public static function throwCustomError($message, $heading = 'Symphony Fatal Error', $status = Page::HTTP_STATUS_ERROR, $template = 'generic', array $additional = array())
-    {
-        GenericExceptionHandler::$enabled = true;
-        throw new SymphonyErrorPage($message, $heading, $template, $additional, $status);
+        return self::$exception;
     }
 
     /**
@@ -791,17 +820,6 @@ abstract class Symphony implements Singleton
     public static function setException(Exception $ex)
     {
         self::$exception = $ex;
-    }
-
-    /**
-     * Accessor for `self::$exception`.
-     *
-     * @since Symphony 2.3.2
-     * @return Exception|null
-     */
-    public static function getException()
-    {
-        return self::$exception;
     }
 
     /**
@@ -846,7 +864,7 @@ abstract class Symphony implements Singleton
             if ($bits[0] === 'extension') {
                 self::$namespace = sprintf('/%s/%s/%s', $bits[0], $bits[1], $bits[2]);
             } else {
-                self::$namespace =  sprintf('/%s/%s', $bits[0], isset($bits[1]) ? $bits[1] : '');
+                self::$namespace = sprintf('/%s/%s', $bits[0], isset($bits[1]) ? $bits[1] : '');
             }
         }
 

--- a/symphony/lib/toolkit/class.database.php
+++ b/symphony/lib/toolkit/class.database.php
@@ -70,9 +70,9 @@ Class Database {
     protected $_result = null;
 
     /**
-     * @var array|boolean
+     * @var array
      */
-    protected $_lastResult = null;
+    protected $_lastResult = array();
 
     /**
      * @var string
@@ -128,7 +128,7 @@ Class Database {
     public function flush()
     {
         $this->_result = null;
-        $this->_lastResult = null;
+        $this->_lastResult = array();
         $this->_lastQuery = null;
         $this->_lastQueryHash = null;
     }
@@ -379,7 +379,8 @@ Class Database {
             $params['fetch-type'] = 'ASSOC';
             $this->query($query, $params, $values);
         }
-        else if(is_null($this->_lastResult) || $this->_lastResult === false) {
+
+        if(empty($this->_lastResult)) {
             return array();
         }
 

--- a/symphony/lib/toolkit/class.mysql.php
+++ b/symphony/lib/toolkit/class.mysql.php
@@ -671,7 +671,7 @@ class MySQL
      */
     public function debug($type = null)
     {
-        return MySQL::$_conn_pdo->debug();
+        return MySQL::$_conn_pdo->debug($type);
     }
 
     /**

--- a/test/travis_ci_config.php
+++ b/test/travis_ci_config.php
@@ -1,0 +1,90 @@
+<?php
+return $settings = array (
+  'admin' =>
+  array (
+    'max_upload_size' => '5242880',
+    'upload_blacklist' => '/\\.(?:php[34567s]?|phtml)$/i',
+  ),
+  'symphony' =>
+  array (
+    'admin-path' => 'symphony',
+    'pagination_maximum_rows' => '20',
+    'association_maximum_rows' => '5',
+    'lang' => 'en',
+    'pages_table_nest_children' => 'no',
+    'version' => '3.0.0-alpha.1',
+    'cell_truncation_length' => '75',
+    'enable_xsrf' => 'no',
+  ),
+  'log' =>
+  array (
+    'handler' =>
+    array (
+      'class' => '\\Monolog\\Handler\\StreamHandler',
+      'args' =>
+      array (
+        0 => '{vars.filename}',
+        1 => 100,
+      ),
+    ),
+    'formatter' =>
+    array (
+      'class' => '\\Monolog\\Formatter\\LineFormatter',
+      'args' =>
+      array (
+        0 => '%datetime% > %level_name%: %message% %context% %extra%' . PHP_EOL,
+        1 => '{region.date_format}{region.datetime_separator}{region.time_format}',
+        2 => false,
+        3 => true,
+      ),
+    ),
+  ),
+  'database' =>
+  array (
+    'host' => 'localhost',
+    'port' => '3306',
+    'user' => 'root',
+    'password' => '',
+    'db' => 'symphony_test',
+    'tbl_prefix' => 'sym_',
+    'query_caching' => 'on',
+    'query_logging' => 'on',
+  ),
+  'session' =>
+  array (
+    'admin_session_name' => 'symphony_admin',
+    'public_session_name' => 'symphony_public',
+    'admin_session_expires' => '2 weeks',
+    'public_session_expires' => '2 weeks',
+    'session_gc_probability' => '1',
+    'session_gc_divisor' => '10',
+  ),
+  'public' =>
+  array (
+    'display_event_xml_in_source' => 'no',
+  ),
+  'general' =>
+  array (
+    'sitename' => 'Symphony CMS',
+    'useragent' => 'Symphony/3.0.0-alpha.1',
+  ),
+  'file' =>
+  array (
+    'write_mode' => '0644',
+  ),
+  'directory' =>
+  array (
+    'write_mode' => '0755',
+  ),
+  'region' =>
+  array (
+    'time_format' => 'g:i a',
+    'date_format' => 'm/d/Y',
+    'datetime_separator' => ' ',
+    'timezone' => 'Australia/Brisbane',
+  ),
+  'cache_driver' =>
+  array (
+    'default' => 'database',
+  )
+);


### PR DESCRIPTION
This work includes:
- Introduce `symphony/conductor` which is a little console application for doing things with Symphony, at the moment it has two commands, `requirements` and `install`. Commands are auto discovered inside a `/command` directory in `/extensions`, `/install`, `/symphony` and `/workspace`.
- Refactor Install to make use of Steps. The same code is being reused when installing from CLI or the UI :)
- Introduce TravisCI integration, currently using `phpcs` (we fail terribly at the moment against PSR-2).
- Reinstate `MySQL::import` to it's former glory to get around an issue where PDO drops errors silently.
- Tweak `Configuration::__toString` so it can handle advanced structures (note that the resulting file formatting is still off).
- Minor fixes for MySQL 5.7+.
- Raise PHP minimum to 5.5.9.

**WIP**, don't merge, this is open for visibility.
